### PR TITLE
print table content on error message

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -25,6 +25,42 @@ function assertError(f, ...)
     error( "Expected an error but no error generated", 2 )
 end
 
+function table.val_to_str ( v )
+    if "string" == type( v ) then
+        v = string.gsub( v, "\n", "\\n" )
+        if string.match( string.gsub(v,"[^'\"]",""), '^"+$' ) then
+            return "'" .. v .. "'"
+        end
+        return '"' .. string.gsub(v,'"', '\\"' ) .. '"'
+    else
+        return "table" == type( v ) and table.tostring( v ) or
+            tostring( v )
+    end
+end
+
+function table.key_to_str ( k )
+    if "string" == type( k ) and string.match( k, "^[_%a][_%a%d]*$" ) then
+        return k
+    else
+        return "[" .. table.val_to_str( k ) .. "]"
+    end
+end
+
+function table.tostring( tbl )
+    local result, done = {}, {}
+    for k, v in ipairs( tbl ) do
+        table.insert( result, table.val_to_str( v ) )
+        done[ k ] = true
+    end
+    for k, v in pairs( tbl ) do
+        if not done[ k ] then
+            table.insert( result,
+                table.key_to_str( k ) .. "=" .. table.val_to_str( v ) )
+        end
+    end
+    return "{" .. table.concat( result, "," ) .. "}"
+end
+
 function mytostring( v )
     if type(v) == 'string' then
         return '"'..v..'"'
@@ -33,7 +69,7 @@ function mytostring( v )
         if v.__class__ then
             return string.gsub( tostring(v), 'table', v.__class__ )
         end
-        return tostring(v)
+        return table.tostring(v)
     end
     return tostring(v)
 end


### PR DESCRIPTION
Examples:

not ok 58       TestNGCPRealPrefs:test_callee_usr_load_multi
    ./tests/ngcp_rp.lua:183: expected: {3,2,1}, actual: 3

not ok 82       TestNGCPXAvp:test_xavp_get_all
    ./tests/ngcp_xavp.lua:98: expected: {testid={2,1}}, actual: {testid=2}
