### PR TITLE
fix prettystr stackoverflow issue, and modify test cases

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -177,7 +177,8 @@ end
 
 -- Jennal add @params recurrencyTable
 function table.tostring( tbl, recurrencyTable )
-    recurrencyTable = recurrencyTable or {[tbl] = true}
+    recurrencyTable = recurrencyTable or {}
+    recurrencyTable[tbl] = true
 
     local result, done = {}, {}
     local dispOnMultLines = false
@@ -194,9 +195,6 @@ function table.tostring( tbl, recurrencyTable )
         end
 
         done[ k ] = true
-        if type(v) == "table" then
-            recurrencyTable[v] = true
-        end
     end
 
     for k, v in sortedPairs( tbl ) do
@@ -207,10 +205,6 @@ function table.tostring( tbl, recurrencyTable )
             else
                 table.insert( result,
                     table.keytostring( k ) .. "=" .. prettystr( v, true, recurrencyTable ) )
-            end
-
-            if type(v) == "table" then
-                recurrencyTable[v] = true
             end
         end
     end

--- a/test_luaunit.lua
+++ b/test_luaunit.lua
@@ -196,6 +196,14 @@ TestLuaUnitUtilities = {} --class
         local t = {}
         t.__index = t
         assertStrContains(prettystr(t), "{__index=#ref(table:")
+
+        local t1 = {}
+        local t2 = {}
+        t1.t2 = t2
+        t2.t1 = t1
+        local t3 = { t1 = t1, t2 = t2 }
+        assertStrContains(prettystr(t1), "{t1=#ref(table:")
+        assertStrContains(prettystr(t3), ", t2=#ref(table:")
     end
 
     function TestLuaUnitUtilities:test_IsFunction()


### PR DESCRIPTION
fix this issue

```
local t = {}
t.__index = t
prettystr(t) -- stack overflow
```
