### PR TITLE
Improve on AppVeyor CI

### DIFF
--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -1,0 +1,67 @@
+REM This is a batch file to help with setting up the desired Lua environment.
+REM It is intended to be run as "install" step from within AppVeyor.
+
+REM version numbers and file names for binaries from http://sf.net/p/luabinaries/
+set VER_51=5.1.5
+set VER_52=5.2.3
+set VER_53=5.3.2
+set ZIP_51=lua-%VER_51%_Win32_bin.zip
+set ZIP_52=lua-%VER_52%_Win32_bin.zip
+set ZIP_53=lua-%VER_53%_Win32_bin.zip
+
+:cinst
+if NOT "%LUAENV%"=="cinst" goto lua51
+echo Chocolatey install of Lua ...
+@echo on
+cinst lua
+set LUA="C:\Program Files (x86)\Lua\5.1\lua.exe"
+@echo off
+goto :EOF
+
+:lua51
+if NOT "%LUAENV%"=="lua51" goto lua52
+echo Setting up Lua 5.1 ...
+@echo on
+curl -fLsS -o %ZIP_51% http://sourceforge.net/projects/luabinaries/files/%VER_51%/Tools%%20Executables/%ZIP_51%/download
+unzip %ZIP_51%
+set LUA=lua5.1.exe
+@echo off
+goto :EOF
+
+:lua52
+if NOT "%LUAENV%"=="lua52" goto lua53
+echo Setting up Lua 5.2 ...
+@echo on
+curl -fLsS -o %ZIP_52% http://sourceforge.net/projects/luabinaries/files/%VER_52%/Tools%%20Executables/%ZIP_52%/download
+unzip %ZIP_52%
+set LUA=lua52.exe
+@echo off
+goto :EOF
+
+:lua53
+if NOT "%LUAENV%"=="lua53" goto luajit
+echo Setting up Lua 5.3 ...
+@echo on
+curl -fLsS -o %ZIP_53% http://sourceforge.net/projects/luabinaries/files/%VER_53%/Tools%%20Executables/%ZIP_53%/download
+unzip %ZIP_53%
+set LUA=lua53.exe
+@echo off
+goto :EOF
+
+:luajit
+if NOT "%LUAENV%"=="luajit20" goto luajit21
+echo Setting up LuaJIT 2.0 ...
+@echo on
+curl -fLsS -o luajit.zip https://github.com/luapower/luajit/archive/2.0.zip
+unzip -q luajit.zip
+set LUA=luajit-2.0\luajit32.cmd
+@echo off
+goto :EOF
+
+:luajit21
+echo Setting up LuaJIT 2.1 ...
+@echo on
+curl -fLsS -o luajit.zip https://github.com/luapower/luajit/archive/master.zip
+unzip -q luajit.zip
+set LUA=luajit-master\luajit32.cmd
+@echo off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+shallow_clone: true
+
+# create a build matrix to use various Lua and LuaJIT versions
+environment:
+  matrix:
+    - LUAENV: cinst
+    - LUAENV: lua51
+    - LUAENV: lua52
+    - LUAENV: lua53
+    - LUAENV: luajit20
+    - LUAENV: luajit21
+
+# install required binaries via batch file (also sets %LUA% path)
+install:
+- cmd: .appveyor\install-lua.cmd
+
+build: off
+
+test_script:
+- cmd: >-
+    %LUA% -v run_unit_tests.lua
+
+    %LUA% run_functional_tests.lua

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,11 @@ environment:
     - LUAENV: luajit20
     - LUAENV: luajit21
 
+# cinst occasionally has problems, allow it to fail
+matrix:
+  allow_failures:
+    - LUAENV: cinst
+
 # install required binaries via batch file (also sets %LUA% path)
 install:
 - cmd: .appveyor\install-lua.cmd


### PR DESCRIPTION
This patch is related to #39.

It adds an AppVeyor configuration (appveyor.yml) and a companion
batch file that takes care of installing a variety of Lua and
LuaJIT versions according to the LUAENV setting.

LUAENV gets assigned via the build matrix and currently supports:
"cinst" - Use the Chocolatey package manager to install a default
Lua interpreter (cinst lua). Currently this is Lua 5.1.4
"lua51", "lua52", "lua53" - Retrieve a prebuilt binary version of
Lua (5.1.x, 5.2.x and 5.3.x respectively) from the LuaBinaries
project at sourceforge.
"luajit20", "luajit21" - Retrieve a prebuilt binary version of LuaJIT
(2.0.x or 2.1.x) from the luapower project (see https://luapower.com/)

For now I have activated "cinst" and "lua51" in the build matrix,
even though using both is somewhat redundant.
The remainder of the configuration file is rather minimalistic
and should be self-explanatory.