### PR TITLE
Fix luajit target(s) for AppVeyor CI

### DIFF
--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -3,7 +3,7 @@ REM It is intended to be run as "install" step from within AppVeyor.
 
 REM version numbers and file names for binaries from http://sf.net/p/luabinaries/
 set VER_51=5.1.5
-set VER_52=5.2.3
+set VER_52=5.2.4
 set VER_53=5.3.2
 set ZIP_51=lua-%VER_51%_Win32_bin.zip
 set ZIP_52=lua-%VER_52%_Win32_bin.zip
@@ -51,17 +51,11 @@ goto :EOF
 :luajit
 if NOT "%LUAENV%"=="luajit20" goto luajit21
 echo Setting up LuaJIT 2.0 ...
-@echo on
-curl -fLsS -o luajit.zip https://github.com/luapower/luajit/archive/2.0.zip
-unzip -q luajit.zip
-set LUA=luajit-2.0\luajit32.cmd
-@echo off
+call %~dp0install-luajit.cmd LuaJIT-2.0.4
+set LUA=luajit.exe
 goto :EOF
 
 :luajit21
 echo Setting up LuaJIT 2.1 ...
-@echo on
-curl -fLsS -o luajit.zip https://github.com/luapower/luajit/archive/master.zip
-unzip -q luajit.zip
-set LUA=luajit-master\luajit32.cmd
-@echo off
+call %~dp0install-luajit.cmd LuaJIT-2.1.0-beta2
+set LUA=luajit.exe

--- a/.appveyor/install-luajit.cmd
+++ b/.appveyor/install-luajit.cmd
@@ -1,0 +1,20 @@
+REM Do a minimalistic build of LuaJIT using the MinGW compiler
+
+set PATH=C:\MinGW\bin;%PATH%
+@echo on
+REM retrieve and unpack source
+curl -fLsS -o %1.zip http://luajit.org/download/%1.zip
+unzip -q %1
+
+REM tweak Makefile for a static LuaJIT build (Windows defaults to "dynamic" otherwise)
+sed -i "s/BUILDMODE=.*mixed/BUILDMODE=static/" %1\src\Makefile
+
+mingw32-make TARGET_SYS=Windows -C %1\src
+
+REM copy luajit.exe to project dir
+copy %1\src\luajit.exe %APPVEYOR_BUILD_FOLDER%
+
+@echo off
+REM clean up (remove source folders and archive)
+rm -rf %1/*
+rm -f %1.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+os: MinGW
 shallow_clone: true
 
 # create a build matrix to use various Lua and LuaJIT versions


### PR DESCRIPTION
The luapower project has removed its "2.0" branch, breaking our
binary deployment of LuaJIT v2.0 ("luajit20" target). I have modified
the installation batch files to instead build luajit20 (LuaJIT-2.0.4)
and luajit21 (LuaJIT-2.1.0-beta2) straight from the official sources
now.