### PR TITLE
Determine access to undefined variables by static analysis

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,7 +8,6 @@ only = {"1"} -- limit checks to the use of global variables
 std = "max"
 -- The files below are still problematic, exclude them for now
 exclude_files = {
-	"run_functional_tests.lua",
 	"test/compat_luaunit_v2x.lua",
 	"test/legacy_example_with_luaunit.lua",
 	"test/test_with_err_fail_pass.lua",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,44 @@
+--[[
+Luacheck configuration
+(see http://luacheck.readthedocs.io/en/stable/config.html)
+Thanks to Peter Melnichenko for providing an example file for LuaUnit.
+]]
+
+only = {"1"} -- limit checks to the use of global variables
+std = "max"
+-- The files below are still problematic, exclude them for now
+exclude_files = {
+	"run_functional_tests.lua",
+	"test/compat_luaunit_v2x.lua",
+	"test/legacy_example_with_luaunit.lua",
+	"test/test_with_err_fail_pass.lua",
+	"test/test_with_xml.lua"
+}
+
+files = {
+    ["luaunit.lua"] = {
+        ignore = {"LuaUnit", "EXPORT_ASSERT_TO_GLOBALS"}
+    },
+    ["example_with_luaunit.lua"] = {
+        ignore = {"LuaUnit", "EXPORT_ASSERT_TO_GLOBALS", "[Tt]est[%w_]+",
+        "assertEquals", "assertNotEquals", "assertTrue", "assertFalse"}
+    },
+    ["run_functional_tests.lua"] = {
+        ignore = {"test%w+"}
+    },
+    ["test/compat_luaunit_v2x.lua"] = {
+        ignore = {"EXPORT_ASSERT_TO_GLOBALS", "[Tt]est[%w_]+", "assert%w+"}
+    },
+    ["test/legacy_example_with_luaunit.lua"] = {
+        ignore = {"LuaUnit", "EXPORT_ASSERT_TO_GLOBALS", "[Tt]est[%w_]+",
+        "assertEquals", "assertNotEquals", "assertTrue", "assertFalse"}
+    },
+    ["test/test_luaunit.lua"] = {
+        ignore = {"TestMock", "TestLuaUnit%a+", "MyTest%w+"}},
+    ["test/test_with_err_fail_pass.lua"] = {
+        ignore = {"[Tt]est[%w_]+"}
+    },
+    ["test/test_with_xml.lua"] = {
+        ignore = {"Test%w+"}
+    }
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,13 +6,6 @@ Thanks to Peter Melnichenko for providing an example file for LuaUnit.
 
 only = {"1"} -- limit checks to the use of global variables
 std = "max"
--- The files below are still problematic, exclude them for now
-exclude_files = {
-	"test/compat_luaunit_v2x.lua",
-	"test/legacy_example_with_luaunit.lua",
-	"test/test_with_err_fail_pass.lua",
-	"test/test_with_xml.lua"
-}
 
 files = {
     ["luaunit.lua"] = {

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,12 @@ matrix:
 
 before_install:
   - source .travis/setenv_lua.sh
+  - luarocks install luacheck
 
 script: 
   - lua -v run_unit_tests.lua
   - lua run_functional_tests.lua
+  - luacheck *.lua test/
 
 notifications:
   email:

--- a/example_with_luaunit.lua
+++ b/example_with_luaunit.lua
@@ -137,6 +137,6 @@ function test3()
     assert( 'a' == 'a')
 end
 
-lu = LuaUnit.new()
+local lu = LuaUnit.new()
 lu:setOutputType("tap")
 os.exit( lu:runSuite() )

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1018,7 +1018,7 @@ local list_of_funcs = {
 
 -- Create all aliases in M
 for _,v in ipairs( list_of_funcs ) do
-    funcname, alias = v[1], v[2]
+    local funcname, alias = v[1], v[2]
     M[alias] = M[funcname]
 
     if EXPORT_ASSERT_TO_GLOBALS then

--- a/run_functional_tests.lua
+++ b/run_functional_tests.lua
@@ -1,14 +1,14 @@
 #!/usr/bin/env lua
 
 require('os')
-lu = require('luaunit')
+local lu = require('luaunit')
 
 
-function report( ... )
+local function report( ... )
     print('>>>>>>>', string.format(...))
 end
 
-function error_fmt( ... )
+local function error_fmt( ... )
     error(string.format(...), 2) -- (level 2 = report chunk calling error_fmt)
 end
 
@@ -21,11 +21,11 @@ local LUA='"'..arg[-1]..'"'
 -- with a percent sign. Note: We DON'T expect embedded NUL chars, and thus
 -- won't escape those (%z) for Lua 5.1.
 local LUA_MAGIC_CHARS = "[%^%$%(%)%%%.%[%]%*%+%-%?]"
-function escape_lua_pattern(s)
+local function escape_lua_pattern(s)
     return s:gsub(LUA_MAGIC_CHARS, "%%%1") -- substitute with '%' + matched char
 end
 
-function string_sub(s, orig, repl)
+local function string_sub(s, orig, repl)
     -- replace occurrence of string orig by string repl
     -- just like string.gsub, but with no pattern matching
     return s:gsub( escape_lua_pattern(orig), repl )
@@ -36,7 +36,7 @@ function testStringSub()
     lu.assertEquals( string_sub('aa: ?cc', ': ?', 'xx?'), 'aaxx?cc' )
 end
 
-function osExec( ... )
+local function osExec( ... )
     -- execute a command with os.execute and return true if exit code is 0
     -- false in any other conditions
 
@@ -86,7 +86,7 @@ function osExec( ... )
     return true, exitCode
 end
 
-function osExpectedCodeExec( refExitCode, ... )
+local function osExpectedCodeExec( refExitCode, ... )
     local cmd = string.format(...)
     local ret, exitCode = osExec( cmd )
     if refExitCode and (exitCode ~= refExitCode) then
@@ -97,7 +97,7 @@ end
 
 local HAS_XMLLINT 
 do
-    xmllint_output_fname = 'test/has_xmllint.txt'
+    local xmllint_output_fname = 'test/has_xmllint.txt'
     HAS_XMLLINT = osExec('xmllint --version 2> '..xmllint_output_fname)
     if not HAS_XMLLINT then
         report('WARNING: xmllint absent, can not validate xml validity')
@@ -105,7 +105,7 @@ do
     os.remove(xmllint_output_fname)
 end
 
-function adjustFile( fileOut, fileIn, pattern, mayBeAbsent, verbose )
+local function adjustFile( fileOut, fileIn, pattern, mayBeAbsent, verbose )
     --[[ Adjust the content of fileOut by copying lines matching pattern from fileIn
 
     fileIn lines are read and the first line matching pattern is analysed. The first pattern
@@ -168,7 +168,7 @@ function adjustFile( fileOut, fileIn, pattern, mayBeAbsent, verbose )
     f:close()
 end
 
-function check_tap_output( fileToRun, options, output, refOutput, refExitCode )
+local function check_tap_output( fileToRun, options, output, refOutput, refExitCode )
     -- remove output
     osExpectedCodeExec(refExitCode, '%s %s --output TAP %s > %s',
                        LUA, fileToRun, options, output)
@@ -186,7 +186,7 @@ function check_tap_output( fileToRun, options, output, refOutput, refExitCode )
 end
 
 
-function check_text_output( fileToRun, options, output, refOutput, refExitCode )
+local function check_text_output( fileToRun, options, output, refOutput, refExitCode )
     -- remove output
     osExpectedCodeExec(refExitCode, '%s %s --output text %s > %s',
                        LUA, fileToRun, options, output)
@@ -205,7 +205,7 @@ function check_text_output( fileToRun, options, output, refOutput, refExitCode )
     return 0
 end
 
-function check_nil_output( fileToRun, options, output, refOutput, refExitCode )
+local function check_nil_output( fileToRun, options, output, refOutput, refExitCode )
     -- remove output
     osExpectedCodeExec(refExitCode, '%s %s --output nil %s > %s',
                        LUA, fileToRun, options, output)
@@ -217,7 +217,7 @@ function check_nil_output( fileToRun, options, output, refOutput, refExitCode )
     return 0
 end
 
-function check_xml_output( fileToRun, options, output, xmlOutput, xmlLintOutput, refOutput, refXmlOutput, refExitCode )
+local function check_xml_output( fileToRun, options, output, xmlOutput, xmlLintOutput, refOutput, refXmlOutput, refExitCode )
     local retcode = 0
 
     -- remove output
@@ -537,29 +537,29 @@ function testStopOnError()
             'test/ref/errFailPassTextStopOnError-4.txt', -2 ) )
 end
 
-filesToGenerateExampleXml = {
+local filesToGenerateExampleXml = {
     { 'example_with_luaunit.lua', '', '--output junit --name test/ref/exampleXmlDefault.xml', 'test/ref/exampleXmlDefault.txt' },
     { 'example_with_luaunit.lua', '--quiet', '--output junit --name test/ref/exampleXmlQuiet.xml', 'test/ref/exampleXmlQuiet.txt' },
     { 'example_with_luaunit.lua', '--verbose', '--output junit --name test/ref/exampleXmlVerbose.xml', 'test/ref/exampleXmlVerbose.txt' },
 }
 
-filesToGenerateExampleTap = {
+local filesToGenerateExampleTap = {
     { 'example_with_luaunit.lua', '', '--output tap', 'test/ref/exampleTapDefault.txt' },
     { 'example_with_luaunit.lua', '--quiet', '--output tap', 'test/ref/exampleTapQuiet.txt' },
     { 'example_with_luaunit.lua', '--verbose', '--output tap', 'test/ref/exampleTapVerbose.txt' },
 }
 
-filesToGenerateExampleText = {
+local filesToGenerateExampleText = {
     { 'example_with_luaunit.lua', '', '--output text', 'test/ref/exampleTextDefault.txt' },
     { 'example_with_luaunit.lua', '--quiet', '--output text', 'test/ref/exampleTextQuiet.txt' },
     { 'example_with_luaunit.lua', '--verbose', '--output text', 'test/ref/exampleTextVerbose.txt' },
 }
 
-filesToGenerateExampleNil = {
+local filesToGenerateExampleNil = {
     { 'example_with_luaunit.lua', '', '--output nil', 'test/ref/exampleNilDefault.txt' },
 }
 
-filesToGenerateErrFailPassXml = {
+local filesToGenerateErrFailPassXml = {
     { 'test/test_with_err_fail_pass.lua', '', 
         '--output junit --name test/ref/errFailPassXmlDefault.xml', 
         'test/ref/errFailPassXmlDefault.txt' },
@@ -586,7 +586,7 @@ filesToGenerateErrFailPassXml = {
         'test/ref/errFailPassXmlVerbose-failures.txt' },
 }
 
-filesToGenerateErrFailPassTap = {
+local filesToGenerateErrFailPassTap = {
     { 'test/test_with_err_fail_pass.lua', '', '--output tap', 'test/ref/errFailPassTapDefault.txt' },
     { 'test/test_with_err_fail_pass.lua', '-p Succ', '--output tap', 'test/ref/errFailPassTapDefault-success.txt' },
     { 'test/test_with_err_fail_pass.lua', '-p Succ -p Fail', '--output tap', 'test/ref/errFailPassTapDefault-failures.txt' },
@@ -604,7 +604,7 @@ filesToGenerateErrFailPassTap = {
         '--output tap', 'test/ref/errFailPassTapVerbose-failures.txt' },
 }
 
-filesToGenerateErrFailPassText = {
+local filesToGenerateErrFailPassText = {
     { 'test/test_with_err_fail_pass.lua', '', '--output text', 'test/ref/errFailPassTextDefault.txt' },
     { 'test/test_with_err_fail_pass.lua', '-p Succ', '--output text', 'test/ref/errFailPassTextDefault-success.txt' },
     { 'test/test_with_err_fail_pass.lua', '-p Succ -p Fail', '--output text', 'test/ref/errFailPassTextDefault-failures.txt' },
@@ -620,13 +620,13 @@ filesToGenerateErrFailPassText = {
         '--output text', 'test/ref/errFailPassTextVerbose-failures.txt' },
 }
 
-filesToGenerateTestXml = {
+local filesToGenerateTestXml = {
     { 'test/test_with_xml.lua', '', '--output junit --name test/ref/testWithXmlDefault.xml', 'test/ref/testWithXmlDefault.txt' },
     { 'test/test_with_xml.lua', '--verbose', '--output junit --name test/ref/testWithXmlVerbose.xml', 'test/ref/testWithXmlVerbose.txt' },
     { 'test/test_with_xml.lua', '--quiet', '--output junit --name test/ref/testWithXmlQuiet.xml', 'test/ref/testWithXmlQuiet.txt' },
 }
 
-filesToGenerateStopOnError = {
+local filesToGenerateStopOnError = {
     { 'test/test_with_err_fail_pass.lua', '', '--output text --quiet -p Succ --error --failure',
         'test/ref/errFailPassTextStopOnError-1.txt'},
     { 'test/test_with_err_fail_pass.lua', '', '--output text --quiet -p TestSome --error',
@@ -637,7 +637,7 @@ filesToGenerateStopOnError = {
         'test/ref/errFailPassTextStopOnError-4.txt'},
 }
 
-filesSetIndex = {
+local filesSetIndex = {
     ErrFailPassText=filesToGenerateErrFailPassText,
     ErrFailPassTap=filesToGenerateErrFailPassTap,
     ErrFailPassXml=filesToGenerateErrFailPassXml,
@@ -649,7 +649,7 @@ filesSetIndex = {
     StopOnError=filesToGenerateStopOnError,
 }
 
-function updateRefFiles( filesToGenerate )
+local function updateRefFiles( filesToGenerate )
     local ret
 
     for i,v in ipairs(filesToGenerate) do 
@@ -671,7 +671,7 @@ function updateRefFiles( filesToGenerate )
 end
 
 
-function main()
+local function main()
     if arg[1] == '--update' then
         if #arg == 1 then
             -- generate all files
@@ -683,7 +683,7 @@ function main()
         else
             -- generate subset of files
             for i = 2, #arg do
-                fileSet = filesSetIndex[ arg[i] ]
+                local fileSet = filesSetIndex[ arg[i] ]
                 if fileSet == nil then
                     local validTarget = ''
                     for k,v in pairs(filesSetIndex) do

--- a/run_unit_tests.lua
+++ b/run_unit_tests.lua
@@ -1,7 +1,7 @@
 #!/usr/bin/env lua
 
 require('test.test_luaunit')
-lu = require('luaunit')
+local lu = require('luaunit')
 
 lu.LuaUnit.verbosity = 2
 os.exit( lu.LuaUnit.run() )

--- a/test/compat_luaunit_v2x.lua
+++ b/test/compat_luaunit_v2x.lua
@@ -1,5 +1,5 @@
 EXPORT_ASSERT_TO_GLOBALS = true
-lu = require('luaunit')
+local lu = require('luaunit')
 
 --[[
 Use Luaunit in the v2.1 fashion and check that it still works. 
@@ -37,7 +37,7 @@ function TestLuaUnitV2Compat:testWrapFunctionsAliases()
     assertEquals( lu.wrapFunctions, lu.wrap_functions )
 end
 
-function typeAsserter( goodType, badType, goodAsserter, badAsserter )
+local function typeAsserter( goodType, badType, goodAsserter, badAsserter )
     goodAsserter( goodType )
     badAsserter( badType )
 end
@@ -83,7 +83,7 @@ function TestLuaUnitV2Compat:testTableEquality()
 end
 
 -- Setup
-called = {}
+local called = {}
 
 function test_w1() called.w1 = true end
 function test_w2() called.w2 = true end
@@ -132,4 +132,3 @@ assert( called.tearDown == true )
 assert( called.TearDown == true )
 
 os.exit( results )
-

--- a/test/legacy_example_with_luaunit.lua
+++ b/test/legacy_example_with_luaunit.lua
@@ -135,6 +135,6 @@ function test3()
     assert( 'a' == 'a')
 end
 
-lu = LuaUnit.new()
+local lu = LuaUnit.new()
 lu:setOutputType("tap")
 os.exit( lu:runSuite() )

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -15,9 +15,9 @@ end
 
 -- This is a bit tricky since the test uses the features that it tests.
 
-lu = require('luaunit')
+local lu = require('luaunit')
 
-Mock = { __class__ = 'Mock' }
+local Mock = { __class__ = 'Mock' }
 
 function Mock.new(runner)
     local t = lu.genericOutput.new(runner)
@@ -1618,6 +1618,7 @@ TestLuaUnitErrorMsg = {} --class
 --
 ------------------------------------------------------------------
 
+local executedTests
 
 MyTestToto1 = {} --class
     function MyTestToto1:test1() table.insert( executedTests, "MyTestToto1:test1" ) end

--- a/test/test_with_err_fail_pass.lua
+++ b/test/test_with_err_fail_pass.lua
@@ -1,4 +1,4 @@
-lu = require('luaunit')
+local lu = require('luaunit')
 
 --[[ Test used by functional tests ]]
 TestSomething = {} --class
@@ -20,11 +20,11 @@ TestSomething = {} --class
     end
 
     function TestSomething:test3_Err1()
-        v = 1 + { 1,2 }
+        local v = 1 + { 1,2 }
     end
 
     function TestSomething:test3_Err2()
-        v = 1 + { 1,2 }
+        local v = 1 + { 1,2 }
     end
 
 TestAnotherThing = {} --class
@@ -38,11 +38,11 @@ TestAnotherThing = {} --class
     end
 
     function TestAnotherThing:test2_Err1()
-        v = 1 + { 1,2 }
+        local v = 1 + { 1,2 }
     end
 
     function TestAnotherThing:test2_Err2()
-        v = 1 + { 1,2 }
+        local v = 1 + { 1,2 }
     end
 
     function TestAnotherThing:test3_Fail1()
@@ -63,9 +63,9 @@ function testFuncFail1()
 end
 
 function testFuncErr1()
-    v = 1 + { 1,2 }
+    local v = 1 + { 1,2 }
 end
 
-runner = lu.LuaUnit.new()
+local runner = lu.LuaUnit.new()
 runner:setOutputType("text")
 os.exit( runner:runSuite() )

--- a/test/test_with_xml.lua
+++ b/test/test_with_xml.lua
@@ -1,5 +1,5 @@
 
-lu = require('luaunit')
+local lu = require('luaunit')
 
 TestFailuresWithXml = {} --class
 


### PR DESCRIPTION
This picks up a suggestion from #53 to have some automated checks for missing local keywords (introducing unwanted "globals").

For that purpose, the first patch in the series modifies the Travis CI configuration to make use of [Luacheck](https://github.com/mpeterv/luacheck). The remaining ones deal with cleanup of the current code base.

Thanks to @linuxmaniac for pointing me to Luacheck, and @mpeterv for joining in and providing help and a sample configuration!