### PR TITLE
Improved _table_tostring and _is_table_equals functions for some recursive tables

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -551,15 +551,18 @@ local function _is_table_equals(actual, expected, recursions)
                 if not candidates then return false end
                 for i, candidate in pairs(candidates) do
                     if _is_table_equals(candidate, k) then
-                        found = candidate
-                        -- Remove the candidate we matched against from the list
-                        -- of candidates, so each key in actual can only match
-                        -- one key in expected.
-                        candidates[i] = nil
-                        break
+                        if _is_table_equals(actual[candidate], v) then
+                            found = candidate
+                            -- Remove the candidate we matched against from the list
+                            -- of candidates, so each key in actual can only match
+                            -- one key in expected.
+                            candidates[i] = nil
+                            break
+                        end
+                        -- keys match but values don't, keep searching
                     end
                 end
-                if not(found and _is_table_equals(actual[found], v)) then
+                if not found then
                     -- Either no matching key, or a different value
                     return false
                 end

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -388,13 +388,13 @@ local function prettystrPadded(value1, value2, suffix_a, suffix_b)
 end
 M.private.prettystrPadded = prettystrPadded
 
-local function _table_keytostring(k)
+local function _table_keytostring(k, indentLevel, keeponeline, printTableRefs, recursionTable)
     -- like prettystr but do not enclose with "" if the string is just alphanumerical
     -- this is better for displaying table keys who are often simple strings
     if "string" == type(k) and k:match("^[_%a][_%w]*$") then
         return k
     end
-    return prettystr(k)
+    return prettystr_sub(k, indentLevel, keeponeline, printTableRefs, recursionTable)
 end
 M.private._table_keytostring = _table_keytostring
 
@@ -419,7 +419,7 @@ local function _table_tostring( tbl, indentLevel, printTableRefs, recursionTable
             recursionTable.recursionDetected = true
             entry = "<"..tostring(k)..">="
         else
-            entry = _table_keytostring( k ) .. "="
+            entry = _table_keytostring( k, indentLevel+1, true, printTableRefs, recursionTable ) .. "="
         end
         if recursionTable[v] then
             -- recursion in the value detected!

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -694,9 +694,13 @@ TestLuaUnitAssertions = {} --class
         lu.TABLE_EQUALS_KEYBYCONTENT = false
         assertFailure( lu.assertEquals, {[{}] = 1}, { [{}] = 1})
         assertFailure( lu.assertEquals, {[{one=1, two=2}] = 1}, { [{two=2, one=1}] = 1})
+        assertFailure( lu.assertEquals, {[{1}]=2, [{1}]=3}, {[{1}]=3, [{1}]=2} )
         lu.TABLE_EQUALS_KEYBYCONTENT = true
         lu.assertEquals( {[{}] = 1}, { [{}] = 1})
         lu.assertEquals( {[{one=1, two=2}] = 1}, { [{two=2, one=1}] = 1})
+        lu.assertEquals( {[{1}]=2, [{1}]=3}, {[{1}]=3, [{1}]=2} )
+        -- try the other order as well, in case pairs() returns items reversed in the test above
+        lu.assertEquals( {[{1}]=2, [{1}]=3}, {[{1}]=2, [{1}]=3} )
 
         assertFailure( lu.assertEquals, 1, 2)
         assertFailure( lu.assertEquals, 1, "abc" )
@@ -722,6 +726,8 @@ TestLuaUnitAssertions = {} --class
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{one=1}] = 2})
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{}] = 1, 2})
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{}] = 1, [{}] = 1})
+        assertFailure( lu.assertEquals, {[{"one"}]=1}, {[{"one", 1}]=2} )
+        assertFailure( lu.assertEquals, {[{"one"}]=1,[{"one"}]=1}, {[{"one"}]=1} )
         lu.TABLE_EQUALS_KEYBYCONTENT = config_saved
     end
 

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -178,19 +178,80 @@ TestLuaUnitUtilities = {} --class
     function TestLuaUnitUtilities:test_is_table_equals()
         -- Make sure that _is_table_equals() doesn't fall for these traps
         -- (See https://github.com/bluebird75/luaunit/issues/48)
-        local A, B, C = {}, {}, {}
+        local A, B, C, D = {}, {}, {}, {}
 
+        -- (111;1) both are recurring in the same way, other fields are the same
         A.self = A
         B.self = B
-        lu.assertNotEquals(A, B)
         lu.assertEquals(A, A)
+        lu.assertEquals(A, B)
 
-        A, B = {}, {}
+        -- (111;0) both are recurring in the same way, other fields differ
+        A, B = {1}, {-1}
+        A.self = A
+        B.self = B
+        lu.assertEquals(A, A)
+        lu.assertNotEquals(A, B)
+
+        -- (10;1) only one (either actual or expected) is recurring, other fields are the same
+        A, B = {1}, {1}
+        A.ref = A
+        B.ref = B
+        C = {1, ref=B}
+        lu.assertEquals( A, A )
+        lu.assertEquals( B, B )
+        lu.assertEquals( C, C )
+        lu.assertEquals( A.ref, C.ref )
+        lu.assertEquals( C.ref, A.ref )
+        lu.assertNotEquals( A, C )
+        lu.assertNotEquals( C, A )
+
+        -- (10;0) only one (either actual or expected) is recurring, other fields differ
+        A, B = {1}, {-1}
+        A.ref = A
+        B.ref = B
+        C = {1, ref=B}
+        lu.assertEquals( A, A )
+        lu.assertEquals( B, B )
+        lu.assertEquals( C, C )
+        lu.assertNotEquals( A.ref, C.ref )
+        lu.assertNotEquals( C.ref, A.ref )
+        lu.assertNotEquals( A, C )
+        lu.assertNotEquals( C, A )
+
+        -- (110;1) both are recurring but are different from each other, other fields are the same
+        A, B, C, D = {1}, {1}, {1}, {1}
+        A.ref = B
+        B.ref = A
+        C.ref = D
+        D.ref = D
+        lu.assertEquals( A, A )
+        lu.assertEquals( B, B )
+        lu.assertEquals( C, C )
+        lu.assertEquals( D, D )
+        lu.assertNotEquals( A, C )
+        lu.assertNotEquals( C, A )
+
+        -- (110;0) both are recurring but are different from each other, other fields differ
+        A, B, C, D = {1}, {-1}, {1}, {-1}
+        A.ref = B
+        B.ref = A
+        C.ref = D
+        D.ref = D
+        lu.assertEquals( A, A )
+        lu.assertEquals( B, B )
+        lu.assertEquals( C, C )
+        lu.assertEquals( D, D )
+        lu.assertNotEquals( A, C )
+        lu.assertNotEquals( C, A )
+
+        A, B, C = {}, {}, {}
         A.circular = C
         B.circular = A
         C.circular = B
-        lu.assertNotEquals(A, B)
         lu.assertEquals(C, C)
+        lu.assertEquals(A, B)
+        lu.assertEquals(B, A)
 
         A = {}
         A[{}] = A

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -220,6 +220,9 @@ TestLuaUnitUtilities = {} --class
         lu.assertEquals( lu.prettystr( { [{}] = 1 }), '{{}=1}' )
         lu.assertEquals( lu.prettystr( { 1, [{}] = 1, 2 }), '{1, 2, {}=1}' )
         lu.assertEquals( lu.prettystr( { 1, [{one=1}] = 1, 2, "test", false }), '{1, 2, "test", false, {one=1}=1}' )
+        lu.assertEquals( lu.prettystr( {["foo\nbar"] = 1}), [[{"foo\nbar"=1}]] )
+        lu.assertEquals( lu.prettystr( {["foo'bar"] = 2}), [[{"foo'bar"=2}]] )
+        lu.assertEquals( lu.prettystr( {['foo"bar'] = 3}), [[{'foo"bar'=3}]] )
     end
 
     function TestLuaUnitUtilities:test_prettystr_adv_tables()
@@ -334,6 +337,20 @@ TestLuaUnitUtilities = {} --class
         local t6 = {}
         t6[t6] = 1
         lu.assertStrMatches(lu.prettystr(t6), "<table: (0?x?[%x]+)> {<table: %1>=1}" )
+
+        local t7, t8 = {"t7"}, {"t8"}
+        t7[t8] = 1
+        t8[t7] = 2
+        lu.assertStrMatches(lu.prettystr(t7), '<table: (0?x?[%x]+)> {"t7", <table: (0?x?[%x]+)> {"t8", <table: %1>=2}=1}')
+
+        local t9 = {"t9", {}}
+        t9[{t9}] = 1
+        -- (table) addresses under 64bit are longer, making the resulting string not fit into default line length of 80, triggering multiline display
+        -- hack the line length temporarily
+        local config_LINE_LENGTH = lu.LINE_LENGTH
+        lu.LINE_LENGTH = 160
+        lu.assertStrMatches(lu.prettystr(t9), '<table: (0?x?[%x]+)> {"t9", <table: (0?x?[%x]+)> {}, <table: (0?x?[%x]+)> {<table: %1>}=1}')
+        lu.LINE_LENGTH = config_LINE_LENGTH
     end
 
     function TestLuaUnitUtilities:test_prettystrPadded()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -191,6 +191,14 @@ TestLuaUnitUtilities = {} --class
         C.circular = B
         lu.assertNotEquals(A, B)
         lu.assertEquals(C, C)
+
+        A = {}
+        A[{}] = A
+        lu.assertEquals( A, A )
+
+        A = {}
+        A[A] = 1
+        lu.assertEquals( A, A )
     end
 
     function TestLuaUnitUtilities:test_table_keytostring()
@@ -305,23 +313,27 @@ TestLuaUnitUtilities = {} --class
     function TestLuaUnitUtilities:test_prettystrTableRecursion()
         local t = {}
         t.__index = t
-        lu.assertStrMatches(lu.prettystr(t), "<table: 0?x?[%x]+> {__index=<table: 0?x?[%x]+>}")
+        lu.assertStrMatches(lu.prettystr(t), "<table: (0?x?[%x]+)> {__index=<table: %1>}")
 
         local t1 = {}
         local t2 = {}
         t1.t2 = t2
         t2.t1 = t1
         local t3 = { t1 = t1, t2 = t2 }
-        lu.assertStrMatches(lu.prettystr(t1), "<table: 0?x?[%x]+> {t2=<table: 0?x?[%x]+> {t1=<table: 0?x?[%x]+>}}")
-        lu.assertStrMatches(lu.prettystr(t3), [[<table: 0?x?[%x]+> {
-    t1=<table: 0?x?[%x]+> {t2=<table: 0?x?[%x]+> {t1=<table: 0?x?[%x]+>}},
-    t2=<table: 0?x?[%x]+>
+        lu.assertStrMatches(lu.prettystr(t1), "<table: (0?x?[%x]+)> {t2=<table: (0?x?[%x]+)> {t1=<table: %1>}}")
+        lu.assertStrMatches(lu.prettystr(t3), [[<table: (0?x?[%x]+)> {
+    t1=<table: (0?x?[%x]+)> {t2=<table: (0?x?[%x]+)> {t1=<table: %2>}},
+    t2=<table: %3>
 }]])
 
         local t4 = {1,2}
         local t5 = {3,4,t4}
         t4[3] = t5
-        lu.assertStrMatches(lu.prettystr(t5), "<table: 0?x?[%x]+> {3, 4, <table: 0?x?[%x]+> {1, 2, <table: 0?x?[%x]+>}}")
+        lu.assertStrMatches(lu.prettystr(t5), "<table: (0?x?[%x]+)> {3, 4, (<table: 0?x?[%x]+)> {1, 2, <table: %1>}}")
+
+        local t6 = {}
+        t6[t6] = 1
+        lu.assertStrMatches(lu.prettystr(t6), "<table: (0?x?[%x]+)> {<table: %1>=1}" )
     end
 
     function TestLuaUnitUtilities:test_prettystrPadded()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -219,8 +219,8 @@ TestLuaUnitUtilities = {} --class
         lu.assertEquals( C, C )
         lu.assertEquals( A.ref, C.ref )
         lu.assertEquals( C.ref, A.ref )
-        lu.assertNotEquals( A, C )
-        lu.assertNotEquals( C, A )
+        lu.assertEquals( A, C )
+        lu.assertEquals( C, A )
 
         -- (10;0) only one (either actual or expected) is recurring, other fields differ
         A, B = {1}, {-1}
@@ -245,21 +245,37 @@ TestLuaUnitUtilities = {} --class
         lu.assertEquals( B, B )
         lu.assertEquals( C, C )
         lu.assertEquals( D, D )
-        lu.assertNotEquals( A, C )
-        lu.assertNotEquals( C, A )
+        lu.assertEquals( A, C )
+        lu.assertEquals( C, A )
 
-        -- (110;0) both are recurring but are different from each other, other fields differ
-        A, B, C, D = {1}, {-1}, {1}, {-1}
-        A.ref = B
-        B.ref = A
-        C.ref = D
-        D.ref = D
-        lu.assertEquals( A, A )
-        lu.assertEquals( B, B )
-        lu.assertEquals( C, C )
-        lu.assertEquals( D, D )
-        lu.assertNotEquals( A, C )
-        lu.assertNotEquals( C, A )
+        local config_TABLE_EQUALS_KEYBYCONTENT = lu.TABLE_EQUALS_KEYBYCONTENT
+        lu.TABLE_EQUALS_KEYBYCONTENT = true
+
+        do
+            -- (110;0) both are recurring but are different from each other, other fields differ; tables in values only
+            local A, B, C, D = {1}, {-1}, {1}, {-1}
+            A.ref = B
+            B.ref = A
+            C.ref = D
+            D.ref = D
+            lu.assertEquals( A, A )
+            lu.assertEquals( B, B )
+            lu.assertEquals( C, C )
+            lu.assertEquals( D, D )
+            lu.assertNotEquals( A, C )
+            lu.assertNotEquals( C, A )
+            -- tables in keys (needs TABLE_EQUALS_KEYBYCONTENT=true)
+            A, B, C, D = {1}, {-1}, {1}, {-1}
+            local t2a, t2b, t2c, t2d = {2}, {2}, {2}, {2}
+            A[t2a] = B; B[t2b] = A
+            C[t2c] = D; D[t2d] = D
+            lu.assertEquals( A, A )
+            lu.assertEquals( B, B )
+            lu.assertEquals( C, C )
+            lu.assertEquals( D, D )
+            lu.assertNotEquals( A, C )
+            lu.assertNotEquals( C, A )
+        end
 
         A, B, C = {}, {}, {}
         A.circular = C
@@ -268,9 +284,6 @@ TestLuaUnitUtilities = {} --class
         lu.assertEquals(C, C)
         lu.assertEquals(A, B)
         lu.assertEquals(B, A)
-
-        local config_TABLE_EQUALS_KEYBYCONTENT = lu.TABLE_EQUALS_KEYBYCONTENT
-        lu.TABLE_EQUALS_KEYBYCONTENT = true
 
         A = {}
         A[{}] = A
@@ -297,8 +310,8 @@ TestLuaUnitUtilities = {} --class
             lu.assertEquals(E, B); lu.assertEquals(D[2], A[2])
             lu.assertEquals(C, E); lu.assertEquals(A[3], D[3])
             lu.assertEquals(E, C); lu.assertEquals(D[3], A[3])
-            lu.assertNotEquals(A, D)
-            lu.assertNotEquals(D, A)
+            lu.assertEquals(A, D)
+            lu.assertEquals(D, A)
             -- tables in keys (needs TABLE_EQUALS_KEYBYCONTENT=true)
             A[2] = nil; A[3] = nil; D[2] = nil; D[3] = nil
             local t2b, t2e, t3c, t3e = {2}, {2}, {3}, {3}
@@ -309,8 +322,8 @@ TestLuaUnitUtilities = {} --class
             lu.assertEquals(D[t2e], A[t2b])
             lu.assertEquals(A[t3c], D[t3e])
             lu.assertEquals(D[t3e], A[t3c])
-            lu.assertNotEquals(A, D)
-            lu.assertNotEquals(D, A)
+            lu.assertEquals(A, D)
+            lu.assertEquals(D, A)
         end
 
         do
@@ -338,8 +351,8 @@ TestLuaUnitUtilities = {} --class
             lu.assertEquals(EE, BB); lu.assertEquals(D[2][2], A[2][2])
             lu.assertEquals(CC, EE); lu.assertEquals(A[3][2], D[3][2])
             lu.assertEquals(EE, CC); lu.assertEquals(D[3][2], A[3][2])
-            lu.assertNotEquals(A, D)
-            lu.assertNotEquals(D, A)
+            lu.assertEquals(A, D)
+            lu.assertEquals(D, A)
             -- tables in keys (needs TABLE_EQUALS_KEYBYCONTENT=true)
             A[2] = nil; A[3] = nil; D[2] = nil; D[3] = nil
             local t2b, t2e, t3c, t3f = {2}, {2}, {3}, {3}
@@ -368,8 +381,8 @@ TestLuaUnitUtilities = {} --class
             lu.assertEquals(EE, BB); lu.assertEquals(D[t2e][t2ee], A[t2b][t2bb])
             lu.assertEquals(CC, EE); lu.assertEquals(A[t3c][t2cc], D[t3f][t2ee_])
             lu.assertEquals(EE, CC); lu.assertEquals(D[t3f][t2ee_], A[t3c][t2cc])
-            lu.assertNotEquals(A, D)
-            lu.assertNotEquals(D, A)
+            lu.assertEquals(A, D)
+            lu.assertEquals(D, A)
         end
 
         lu.TABLE_EQUALS_KEYBYCONTENT = config_TABLE_EQUALS_KEYBYCONTENT

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -175,17 +175,32 @@ TestLuaUnitUtilities = {} --class
         lu.assertEquals( lu.private.prefixString( '12 ', 'ab\ncd\nde'), '12 ab\n12 cd\n12 de' )
     end
 
+    local function _is_table_equals_simple(actual, expected)
+        for k, v in pairs(actual) do
+            if v ~= expected[k] then
+                return false
+            end
+        end
+        for k, v in pairs(expected) do
+            if v ~= actual[k] then
+                return false
+            end
+        end
+        return true
+    end
+
     function TestLuaUnitUtilities:test_tablecopy()
         local A = {1, "2", true, false, {}, {3}, [{4}]=5}
         local B = lu.private._table_copy(A)
-        lu.assertItemsEquals(B, A)
+        -- assertItemsEquals ignores keys, assertEquals compares tables by contents, not by reference
+        lu.assertTrue(_is_table_equals_simple(B, A))
         lu.assertTrue(B ~= A)
 
         B = {6, 7, "8", false, true, {}, {9}, [{10}]=11}
         local C = B
-        lu.assertErrorMsgMatches(lu.FAILURE_PREFIX .. "Contents of the tables are not identical:.*", lu.assertItemsEquals, B, A)
+        lu.assertFalse(_is_table_equals_simple(B, A))
         local D = lu.private._table_copy(A, B)
-        lu.assertItemsEquals(B, A)
+        lu.assertTrue(_is_table_equals_simple(B, A))
         lu.assertTrue(B == C)
         lu.assertTrue(D == C)
         lu.assertTrue(D ~= A)


### PR DESCRIPTION
Hello.

I've made some fixes and changes when dealing with some recursive tables. In a sense it's a follow-up to #48 . The goal was to make a deep-copied recursive table equal to the original one.

Changes the output of

    prettystr( {["foo\nbar"] = 1} )

from

    {"foo
    bar"=1}

to

    {"foo\nbar"=1}



Changes the output of

    E = {}; A = {"A", E}; B = {A}; A[B] = 1; prettystr(A)

from (if _PRINT_TABLE_REF_IN_ERROR_MSG=false_)

    {"A", {}, <table: addrB> {<table: addrA> {"A", <table: addrE> {}, <table: addrB>=1}}=1}

and from (if _PRINT_TABLE_REF_IN_ERROR_MSG=true_)

    {"A", <table: addrE> {}, <table: addrB> {<table: addrA> {"A", <table: addrE> {}, <table: addrB>=1}}=1}

to

    <table: addrA> {"A", <table: addrE> {}, <table: addrB> {<table: addrA>}=1}

(actual addresses replaced with placeholders)
This particular test case uses a hack that temporarily overwrites LINE_LENGTH - 
addresses printed out by _tostring(table)_ are longer with 64bit Lua, which triggers multi-line display of the string. With 32bit Lua the string is shorter, so it stays in one line. The threshold in this example seems to be 4 addresses (3 addresses can fit into one line, 4 addresses will be too long).
This seems to be the first test case that is affected by this, so I'm not sure if it's the correct way to deal with this.



Changes the result of test case

    A={}; B={}; A.self = A; B.self = B; assertNotEquals(A, B)

from passing to failing, i.e.

    assertEquals(A, B)

is now passing.



Changes the result of test case

    A,B,C={},{},{}; A.ref=C; B.ref=A; C.ref=B; assertNotEquals(A, B)

from passing to failing, i.e.

    assertEquals(A, B)

is now passing.



The *_is_table_equals* function now tracks recursion of both _actual_ and _expected_ tables and their pairings. If this particular pairing is detected later, it's declared equal, since all other fields up to this time were equal as well (otherwise the inequality will stop the descent and return back).
The descent ends if either _actual_ or _expected_ were previously encountered (and are thus in the appropriate _recursions_ table). If only one of them is recurring, they are declared not equal, even though they could be equal (contents-wise).
Thus there is still room for improvement, although I am not sure how likely is that such convoluted case will be encountered.



Also, code-formatting-style-wise, there are some instances of

    if condition then statement end

that might be split into separate lines, so line code coverage (that @n1tehawk has in one of their branches) could report them in more details.
