### PR TITLE
LuaCov coverage tests support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ obj/
 [Rr]elease*/
 _ReSharper*/
 
+# LuaCov output (stats and report)
+luacov.*.out
+
 # LuaUnit ignores
 [Tt]est[Rr]esult*
 *.sublime-project

--- a/run_functional_tests.lua
+++ b/run_functional_tests.lua
@@ -666,6 +666,10 @@ end
 
 
 local function main()
+    if arg[1] == '--coverage' then
+        LUA = LUA .." -lluacov" -- run tests with LuaCov active
+        table.remove(arg, 1)
+    end
     if arg[1] == '--update' then
         if #arg == 1 then
             -- generate all files


### PR DESCRIPTION
This adds some (very) basic support for running coverage tests on
LuaUnit, using LuaCov (https://github.com/keplerproject/luacov).
LuaCov can be installed using LuaRocks (luarocks install luacov).

Running tests with LuaCov involves loading the "luacov" module
first. run_unit_tests.lua requires no modification and can simply
be run as "$LUA -lluacov run_unit_tests.lua".

However, the functional tests in run_functional_tests.lua do their
own invocation of the Lua interpreter, which needs to be adjusted.
To achieve the desired result, the script now accepts a new option
"--coverage" which will modify the Lua calls accordingly. So to get
coverage analysis, use "./run_functional_tests.lua --coverage".

LuaUnit execution itself should not be affected by this in any way,
except for data collection (in luacov.stats.out). The coverage data
normally needs post-processing to give useful results, see LuaCov
usage instructions for details.