### PR TITLE
Improve _is_table_equals() function and fix various errors

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -623,8 +623,8 @@ local function _is_table_equals(actual, expected, recursions)
                 local found = false
                 -- Note: DON'T use ipairs() here, table may be non-sequential!
                 for i, candidate in pairs(actualTableKeys) do
-                    if _is_table_equals(candidate, k) then
-                        if _is_table_equals(actual[candidate], v) then
+                    if _is_table_equals(candidate, k, recursions) then
+                        if _is_table_equals(actual[candidate], v, recursions) then
                             found = true
                             -- Remove the candidate we matched against from the list
                             -- of table keys, so each key in actual can only match

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -529,22 +529,72 @@ local function _is_table_items_equals(actual, expected )
     return true
 end
 
+--[[
+This is a specialized metatable to help with the bookkeeping of recursions
+in _is_table_equals(). It provides an __index table that implements utility
+functions for easier management of the table. The "cached" method queries
+the state of a specific (actual,expected) pair; and the "store" method sets
+this state to the given value. The state of pairs not "seen" / visited is
+assumed to be `nil`.
+]]
+local _recursion_cache_MT = {
+    __index = {
+        -- Return the cached value for an (actual,expected) pair (or `nil`)
+        cached = function(t, actual, expected)
+            local subtable = t[actual] or {}
+            return subtable[expected]
+        end,
+
+        -- Store cached value for a specific (actual,expected) pair.
+        -- Returns the value, so it's easy to use for a "tailcall" (return ...).
+        store = function(t, actual, expected, value, asymmetric)
+            local subtable = t[actual]
+            if not subtable then
+                subtable = {}
+                t[actual] = subtable
+            end
+            subtable[expected] = value
+
+            -- Unless explicitly marked "asymmetric": Consider the recursion
+            -- on (expected,actual) to be equivalent to (actual,expected) by
+            -- default, and thus cache the value for both.
+            if not asymmetric then
+                t:store(expected, actual, value, true)
+            end
+
+            return value
+        end
+    }
+}
+
 local function _is_table_equals(actual, expected, recursions)
     local type_a, type_e = type(actual), type(expected)
-    recursions = recursions or {}
+    recursions = recursions or setmetatable({}, _recursion_cache_MT)
 
     if type_a ~= type_e then
         return false -- different types won't match
     end
 
-    if (type_a == 'table') --[[ and (type_e == 'table') ]] and not recursions[actual] then
+    if (type_a == 'table') --[[ and (type_e == 'table') ]] then
+        if actual == expected then
+            -- Both reference the same table, so they are actually identical
+            return recursions:store(actual, expected, true)
+        end
+
+        -- If we've tested this (actual,expected) pair before: return cached value
+        local previous = recursions:cached(actual, expected)
+        if previous ~= nil then
+            return previous
+        end
+
+        -- Mark this (actual,expected) pair, so we won't recurse it again. For
+        -- now, assume a "false" result, which we might adjust later if needed.
+        recursions:store(actual, expected, false)
+
         -- Tables must have identical element count, or they can't match.
         if (#actual ~= #expected) then
             return false
         end
-
-        -- add "actual" to the recursions table, to detect and avoid loops
-        recursions[actual] = true
 
         local actualKeysMatched, actualTableKeys = {}, {}
 
@@ -603,7 +653,8 @@ local function _is_table_equals(actual, expected, recursions)
             return false
         end
 
-        return true
+        -- The tables are actually considered equal, update cache and return result
+        return recursions:store(actual, expected, true)
 
     elseif actual ~= expected then
         return false

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -615,21 +615,23 @@ local function _is_table_equals(actual, expected, recursions)
 
         for k, v in pairs(expected) do
             if M.TABLE_EQUALS_KEYBYCONTENT and type(k) == "table" then
-                local found
+                local found = false
                 -- Note: DON'T use ipairs() here, table may be non-sequential!
                 for i, candidate in pairs(actualTableKeys) do
                     if _is_table_equals(candidate, k) then
-                        found = candidate
-                        -- Remove the candidate we matched against from the list
-                        -- of table keys, so each key in actual can only match
-                        -- one key in expected.
-                        actualTableKeys[i] = nil
-                        break
+                        if _is_table_equals(actual[candidate], v) then
+                            found = true
+                            -- Remove the candidate we matched against from the list
+                            -- of table keys, so each key in actual can only match
+                            -- one key in expected.
+                            actualTableKeys[i] = nil
+                            break
+                        end
+                        -- keys match but values don't, keep searching
                     end
                 end
-                if not(found and _is_table_equals(actual[found], v)) then
-                    -- Either no matching key, or a different value
-                    return false
+                if not found then
+                    return false -- no matching (key,value) pair
                 end
             else
                 if not actualKeysMatched[k] then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -430,10 +430,15 @@ local function _table_tostring( tbl, indentLevel, keeponeline, printTableRefs, r
             -- for the sequential part of tables, we'll skip the "<key>=" output
             entry = ''
             seq_index = seq_index + 1
+        elseif recursionTable[k] then
+            -- recursion in the key detected
+            recursionTable.recursionDetected = true
+            entry = "<"..tostring(k)..">="
         else
             entry = keytostring(k) .. "="
         end
-        if recursionTable[v] then -- recursion detected!
+        if recursionTable[v] then
+            -- recursion in the value detected!
             recursionTable.recursionDetected = true
             entry = entry .. "<"..tostring(v)..">"
         else

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -308,23 +308,36 @@ TestLuaUnitUtilities = { __class__ = 'TestLuaUnitUtilities' }
     function TestLuaUnitUtilities:test_prettystrTableRecursion()
         local t = {}
         t.__index = t
-        lu.assertStrMatches(lu.prettystr(t), "<table: 0?x?[%x]+> {__index=<table: 0?x?[%x]+>}")
+        lu.assertStrMatches(lu.prettystr(t), "(<table: 0?x?[%x]+>) {__index=%1}")
 
         local t1 = {}
         local t2 = {}
         t1.t2 = t2
         t2.t1 = t1
         local t3 = { t1 = t1, t2 = t2 }
-        lu.assertStrMatches(lu.prettystr(t1), "<table: 0?x?[%x]+> {t2=<table: 0?x?[%x]+> {t1=<table: 0?x?[%x]+>}}")
-        lu.assertStrMatches(lu.prettystr(t3), [[<table: 0?x?[%x]+> {
-    t1=<table: 0?x?[%x]+> {t2=<table: 0?x?[%x]+> {t1=<table: 0?x?[%x]+>}},
-    t2=<table: 0?x?[%x]+>
+        lu.assertStrMatches(lu.prettystr(t1), "(<table: 0?x?[%x]+>) {t2=(<table: 0?x?[%x]+>) {t1=%1}}")
+        lu.assertStrMatches(lu.prettystr(t3), [[(<table: 0?x?[%x]+>) {
+    t1=(<table: 0?x?[%x]+>) {t2=(<table: 0?x?[%x]+>) {t1=%2}},
+    t2=%3
 }]])
 
         local t4 = {1,2}
         local t5 = {3,4,t4}
         t4[3] = t5
-        lu.assertStrMatches(lu.prettystr(t5), "<table: 0?x?[%x]+> {3, 4, <table: 0?x?[%x]+> {1, 2, <table: 0?x?[%x]+>}}")
+        lu.assertStrMatches(lu.prettystr(t5), "(<table: 0?x?[%x]+>) {3, 4, (<table: 0?x?[%x]+>) {1, 2, %1}}")
+
+        local t6 = {}
+        t6[t6] = 1
+        lu.assertStrMatches(lu.prettystr(t6), "(<table: 0?x?[%x]+>) {%1=1}" )
+
+        local t7, t8 = {"t7"}, {"t8"}
+        t7[t8] = 1
+        t8[t7] = 2
+        lu.assertStrMatches(lu.prettystr(t7), '(<table: 0?x?[%x]+>) {"t7", (<table: 0?x?[%x]+>) {"t8", %1=2}=1}')
+
+        local t9 = {"t9", {}}
+        t9[{t9}] = 1
+        lu.assertStrMatches(lu.prettystr(t9, true), '(<table: 0?x?[%x]+>) {"t9", (<table: 0?x?[%x]+>) {}, (<table: 0?x?[%x]+>) {%1}=1}')
     end
 
     function TestLuaUnitUtilities:test_prettystrPadded()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -188,6 +188,14 @@ TestLuaUnitUtilities = { __class__ = 'TestLuaUnitUtilities' }
         C.circular = B
         lu.assertNotEquals(A, B)
         lu.assertEquals(C, C)
+
+        A = {}
+        A[{}] = A
+        lu.assertEquals( A, A )
+
+        A = {}
+        A[A] = 1
+        lu.assertEquals( A, A )
     end
 
     function TestLuaUnitUtilities:test_prettystr()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -690,9 +690,13 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         lu.TABLE_EQUALS_KEYBYCONTENT = false
         assertFailure( lu.assertEquals, {[{}] = 1}, { [{}] = 1})
         assertFailure( lu.assertEquals, {[{one=1, two=2}] = 1}, { [{two=2, one=1}] = 1})
+        assertFailure( lu.assertEquals, {[{1}]=2, [{1}]=3}, {[{1}]=3, [{1}]=2} )
         lu.TABLE_EQUALS_KEYBYCONTENT = true
         lu.assertEquals( {[{}] = 1}, { [{}] = 1})
         lu.assertEquals( {[{one=1, two=2}] = 1}, { [{two=2, one=1}] = 1})
+        lu.assertEquals( {[{1}]=2, [{1}]=3}, {[{1}]=3, [{1}]=2} )
+        -- try the other order as well, in case pairs() returns items reversed in the test above
+        lu.assertEquals( {[{1}]=2, [{1}]=3}, {[{1}]=2, [{1}]=3} )
 
         assertFailure( lu.assertEquals, 1, 2)
         assertFailure( lu.assertEquals, 1, "abc" )
@@ -718,6 +722,8 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{one=1}] = 2})
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{}] = 1, 2})
         assertFailure( lu.assertEquals, {[{}] = 1}, {[{}] = 1, [{}] = 1})
+        assertFailure( lu.assertEquals, {[{"one"}]=1}, {[{"one", 1}]=2} )
+        assertFailure( lu.assertEquals, {[{"one"}]=1,[{"one"}]=1}, {[{"one"}]=1} )
         lu.TABLE_EQUALS_KEYBYCONTENT = config_saved
     end
 


### PR DESCRIPTION
This pull request incorporates a significant portion of the changes proposed in #57. Merging this would fix a number of actual errors (mostly related to table recursion), and should make it easier to examine - and possibly find a consensus on - the remaining changes.

@AlfonZ42 I'd especially like your feedback on this set of patches. Do you consider these useful in moving forward with your pull request?