### PR TITLE
LD feature newtry

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -26,6 +26,15 @@ M.PRINT_TABLE_REF_IN_ERROR_MSG = false
 M.TABLE_EQUALS_KEYBYCONTENT = true
 M.LINE_LENGTH=80
 
+--[[ EPSILON help Lua in simple corner cases like almostEquals(1.1-0.1, 1),
+which may not work as-is if the user does not provide explicitely some margin
+(e.g. numbers with rational binary representation). The default margin used by
+almostEquals in such case is EPSILON with an initial default value set to
+10^-12. If the user provides a margin, it is used unmodified as a replacement to
+EPSILON, which is then discarded. EPSILON can be changed by the user to suit
+better its needs if the initial default value is not acceptable. ]]--
+M.EPSILON = 1E-12
+
 -- set this to false to debug luaunit
 local STRIP_LUAUNIT_FROM_STACKTRACE=true
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -79,6 +79,8 @@ Options:
 --
 ----------------------------------------------------------------
 
+local assertCount = 0
+
 local crossTypeOrdering = {
     number = 1,
     boolean = 2,
@@ -651,6 +653,7 @@ local function errorMsgEquality(actual, expected)
 end
 
 function M.assertError(f, ...)
+    assertCount = assertCount + 1
     -- assert that calling f with the arguments will raise an error
     -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
     if pcall( f, ... ) then
@@ -659,66 +662,77 @@ function M.assertError(f, ...)
 end
 
 function M.assertIf(value)
+    assertCount = assertCount + 1
     if not value then
         failure("expected: not false or nil, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertNotIf(value)
+    assertCount = assertCount + 1
     if value then
         failure("expected: false or nil, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertTrue(value)
+    assertCount = assertCount + 1
     if value ~= true then
         failure("expected: true, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertFalse(value)
+    assertCount = assertCount + 1
     if value ~= false then
         failure("expected: false, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertIsNil(value)
+    assertCount = assertCount + 1
     if value ~= nil then
         failure("expected: nil, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertNotIsNil(value)
+    assertCount = assertCount + 1
     if value == nil then
         failure("expected non nil value, received nil", 2)
     end
 end
 
 function M.assertIsNaN(value)
+    assertCount = assertCount + 1
     if type(value) ~= "number" or value == value then
         failure("expected: nan, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertNotIsNaN(value)
+    assertCount = assertCount + 1
     if type(value) == "number" and value ~= value then
         failure("expected non nan value, received nan", 2)
     end
 end
 
 function M.assertIsInf(value)
+    assertCount = assertCount + 1
     if type(value) ~= "number" or math.abs(value) ~= 1/0 then
         failure("expected: inf, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertNotIsInf(value)
+    assertCount = assertCount + 1
     if type(value) == "number" and math.abs(value) == 1/0 then
         failure("expected non inf value, received ±inf", 2)
     end
 end
 
 function M.assertEquals(actual, expected)
+    assertCount = assertCount + 1
     if type(actual) == 'table' and type(expected) == 'table' then
         if not _is_table_equals(actual, expected) then
             failure( errorMsgEquality(actual, expected), 2 )
@@ -734,6 +748,7 @@ end
 -- may not work. We need to give a default margin; EPSILON defines the
 -- default value to use for this:
 function M.almostEquals( actual, expected, margin )
+    assertCount = assertCount + 1
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
             prettystr(actual), prettystr(expected), prettystr(margin))
@@ -745,6 +760,7 @@ function M.almostEquals( actual, expected, margin )
 end
 
 function M.assertAlmostEquals( actual, expected, margin )
+    assertCount = assertCount + 1
     -- check that two floats are close by margin
     margin = margin or M.EPSILON
     if not M.almostEquals(actual, expected, margin) then
@@ -757,6 +773,7 @@ function M.assertAlmostEquals( actual, expected, margin )
 end
 
 function M.assertNotEquals(actual, expected)
+    assertCount = assertCount + 1
     if type(actual) ~= type(expected) then
         return
     end
@@ -772,6 +789,7 @@ function M.assertNotEquals(actual, expected)
 end
 
 function M.assertNotAlmostEquals( actual, expected, margin )
+    assertCount = assertCount + 1
     -- check that two floats are not close by margin
     margin = margin or M.EPSILON
     if M.almostEquals(actual, expected, margin) then
@@ -784,6 +802,7 @@ function M.assertNotAlmostEquals( actual, expected, margin )
 end
 
 function M.assertStrContains( str, sub, useRe )
+    assertCount = assertCount + 1
     -- this relies on lua string.find function
     -- a string always contains the empty string
     if not string.find(str, sub, 1, not useRe) then
@@ -794,6 +813,7 @@ function M.assertStrContains( str, sub, useRe )
 end
 
 function M.assertStrIContains( str, sub )
+    assertCount = assertCount + 1
     -- this relies on lua string.find function
     -- a string always contains the empty string
     if not string.find(str:lower(), sub:lower(), 1, true) then
@@ -804,6 +824,7 @@ function M.assertStrIContains( str, sub )
 end
 
 function M.assertNotStrContains( str, sub, useRe )
+    assertCount = assertCount + 1
     -- this relies on lua string.find function
     -- a string always contains the empty string
     if string.find(str, sub, 1, not useRe) then
@@ -814,6 +835,7 @@ function M.assertNotStrContains( str, sub, useRe )
 end
 
 function M.assertNotStrIContains( str, sub )
+    assertCount = assertCount + 1
     -- this relies on lua string.find function
     -- a string always contains the empty string
     if string.find(str:lower(), sub:lower(), 1, true) then
@@ -824,6 +846,7 @@ function M.assertNotStrIContains( str, sub )
 end
 
 function M.assertStrMatches( str, pattern, start, final )
+    assertCount = assertCount + 1
     -- Verify a full match for the string
     -- for a partial match, simply use assertStrContains with useRe set to true
     if not strMatch( str, pattern, start, final ) then
@@ -834,6 +857,7 @@ function M.assertStrMatches( str, pattern, start, final )
 end
 
 function M.assertErrorMsgEquals( expectedMsg, func, ... )
+    assertCount = assertCount + 1
     -- assert that calling f with the arguments will raise an error
     -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
     local no_error, error_msg = pcall( func, ... )
@@ -848,6 +872,7 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
 end
 
 function M.assertErrorMsgContains( partialMsg, func, ... )
+    assertCount = assertCount + 1
     -- assert that calling f with the arguments will raise an error
     -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
     local no_error, error_msg = pcall( func, ... )
@@ -862,6 +887,7 @@ function M.assertErrorMsgContains( partialMsg, func, ... )
 end
 
 function M.assertErrorMsgMatches( expectedMsg, func, ... )
+    assertCount = assertCount + 1
     -- assert that calling f with the arguments will raise an error
     -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
     local no_error, error_msg = pcall( func, ... )
@@ -892,6 +918,7 @@ for _, funcName in ipairs(
                    or error("bad function name '"..funcName.."' for type assertion")
 
     M[funcName] = function(value)
+        assertCount = assertCount + 1
         if type(value) ~= typeExpected then
             fail_fmt(2, 'Expected: a %s value, actual: type %s, value %s',
                      typeExpected, type(value), prettystrPadded(value))
@@ -932,6 +959,7 @@ for _, funcName in ipairs(
                    or error("bad function name '"..funcName.."' for type assertion")
 
     M[funcName] = function(value)
+        assertCount = assertCount + 1
         if type(value) == typeUnexpected then
             fail_fmt(2, 'Not expected: a %s type, actual: value %s',
                      typeUnexpected, prettystrPadded(value))
@@ -940,6 +968,7 @@ for _, funcName in ipairs(
 end
 
 function M.assertIs(actual, expected)
+    assertCount = assertCount + 1
     if actual ~= expected then
         if not M.ORDER_ACTUAL_EXPECTED then
             actual, expected = expected, actual
@@ -951,6 +980,7 @@ function M.assertIs(actual, expected)
 end
 
 function M.assertNotIs(actual, expected)
+    assertCount = assertCount + 1
     if actual == expected then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected = actual
@@ -961,6 +991,7 @@ function M.assertNotIs(actual, expected)
 end
 
 function M.assertItemsEquals(actual, expected)
+    assertCount = assertCount + 1
     -- checks that the items of table expected
     -- are contained in table actual. Warning, this function
     -- is at least O(n^2)
@@ -1447,7 +1478,7 @@ TextOutput.__class__ = 'TextOutput'
 
     function TextOutput:endSuite()
         if self.verbosity > M.VERBOSITY_DEFAULT then
-            print("=========================================================")
+            print("==========================================================================")
         else
             print()
         end
@@ -1808,10 +1839,14 @@ end
     end
 
     function M.LuaUnit.statusLine(result)
+        local chr, cnt = '', assertCount
+        if cnt > 1000 then cnt, chr = cnt/1000, 'K' end
+        if cnt > 1000 then cnt, chr = cnt/1000, 'M' end
+        assertCount = 0
         -- return status line string according to results
         local s = {
-            string.format('Ran %d tests in %0.3f seconds',
-                          result.runCount, result.duration),
+            string.format('Ran %d tests (%d%s asserts) in %0.3f seconds',
+                          result.runCount, cnt, chr, result.duration),
             conditional_plural(result.passedCount, 'success'),
         }
         if result.notPassedCount > 0 then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -707,13 +707,13 @@ function M.assertNotIsNaN(value)
 end
 
 function M.assertIsInf(value)
-    if math.abs(value) ~= 1/0 then
+    if type(value) ~= "number" or math.abs(value) ~= 1/0 then
         failure("expected: inf, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertNotIsInf(value)
-    if math.abs(value) == 1/0 then
+    if type(value) == "number" and math.abs(value) == 1/0 then
         failure("expected non inf value, received ±inf", 2)
     end
 end

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -712,7 +712,8 @@ end
 -- Help Lua in corner cases like almostEquals(1.1, 1.0, 0.1), which by default
 -- may not work. We need to give a default margin; EPSILON defines the
 -- default value to use for this:
-local M.EPSILON = 1E-12
+M.EPSILON = 1E-12
+
 function M.almostEquals( actual, expected, margin )
     margin = margin or M.EPSILON
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -734,7 +734,6 @@ end
 -- may not work. We need to give a default margin; EPSILON defines the
 -- default value to use for this:
 function M.almostEquals( actual, expected, margin )
-    margin = margin or M.EPSILON
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
             prettystr(actual), prettystr(expected), prettystr(margin))
@@ -747,12 +746,13 @@ end
 
 function M.assertAlmostEquals( actual, expected, margin )
     -- check that two floats are close by margin
+    margin = margin or M.EPSILON
     if not M.almostEquals(actual, expected, margin) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end
         fail_fmt(2, 'Values are not almost equal\nExpected: %s with margin of %s, received: %s',
-                 expected, margin or M.EPSILON, actual)
+                 expected, margin, actual)
     end
 end
 
@@ -773,12 +773,13 @@ end
 
 function M.assertNotAlmostEquals( actual, expected, margin )
     -- check that two floats are not close by margin
+    margin = margin or M.EPSILON
     if M.almostEquals(actual, expected, margin) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end
         fail_fmt(2, 'Values are almost equal\nExpected: %s with a difference above margin of %s, received: %s',
-                 expected, margin or M.EPSILON, actual)
+                 expected, margin, actual)
     end
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -33,7 +33,7 @@ almostEquals in such case is EPSILON with an initial default value set to
 10^-12. If the user provides a margin, it is used unmodified as a replacement to
 EPSILON, which is then discarded. EPSILON can be changed by the user to suit
 better its needs if the initial default value is not acceptable. ]]--
-M.EPSILON = 1E-12
+M.EPSILON = 2^-52
 
 -- set this to false to debug luaunit
 local STRIP_LUAUNIT_FROM_STACKTRACE=true
@@ -752,7 +752,7 @@ function M.assertAlmostEquals( actual, expected, margin )
             expected, actual = actual, expected
         end
         fail_fmt(2, 'Values are not almost equal\nExpected: %s with margin of %s, received: %s',
-                 expected, margin, actual)
+                 expected, margin or M.EPSILON, actual)
     end
 end
 
@@ -778,7 +778,7 @@ function M.assertNotAlmostEquals( actual, expected, margin )
             expected, actual = actual, expected
         end
         fail_fmt(2, 'Values are almost equal\nExpected: %s with a difference above margin of %s, received: %s',
-                 expected, margin, actual)
+                 expected, margin or M.EPSILON, actual)
     end
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -697,6 +697,18 @@ function M.assertNotIsNaN(value)
     end
 end
 
+function M.assertIsInf(value)
+    if math.abs(value) ~= 1/0 then
+        failure("expected: inf, actual: " ..prettystr(value), 2)
+    end
+end
+
+function M.assertNotIsInf(value)
+    if math.abs(value) == 1/0 then
+        failure("expected non inf value, received ±inf", 2)
+    end
+end
+
 function M.assertEquals(actual, expected)
     if type(actual) == 'table' and type(expected) == 'table' then
         if not _is_table_equals(actual, expected) then
@@ -1001,6 +1013,7 @@ local list_of_funcs = {
     { 'assertIsBoolean'         , 'assert_is_boolean' },
     { 'assertIsNil'             , 'assert_is_nil' },
     { 'assertIsNaN'             , 'assert_is_nan' },
+    { 'assertIsInf'             , 'assert_is_inf' },
     { 'assertIsFunction'        , 'assert_is_function' },
     { 'assertIsThread'          , 'assert_is_thread' },
     { 'assertIsUserdata'        , 'assert_is_userdata' },
@@ -1012,6 +1025,7 @@ local list_of_funcs = {
     { 'assertIsBoolean'         , 'assertBoolean' },
     { 'assertIsNil'             , 'assertNil' },
     { 'assertIsNaN'             , 'assertNaN' },
+    { 'assertIsInf'             , 'assertInf' },
     { 'assertIsFunction'        , 'assertFunction' },
     { 'assertIsThread'          , 'assertThread' },
     { 'assertIsUserdata'        , 'assertUserdata' },
@@ -1023,6 +1037,7 @@ local list_of_funcs = {
     { 'assertIsBoolean'         , 'assert_boolean' },
     { 'assertIsNil'             , 'assert_nil' },
     { 'assertIsNaN'             , 'assert_nan' },
+    { 'assertIsInf'             , 'assert_inf' },
     { 'assertIsFunction'        , 'assert_function' },
     { 'assertIsThread'          , 'assert_thread' },
     { 'assertIsUserdata'        , 'assert_userdata' },
@@ -1034,6 +1049,7 @@ local list_of_funcs = {
     { 'assertNotIsBoolean'      , 'assert_not_is_boolean' },
     { 'assertNotIsNil'          , 'assert_not_is_nil' },
     { 'assertNotIsNaN'          , 'assert_not_is_nan' },
+    { 'assertNotIsInf'          , 'assert_not_is_inf' },
     { 'assertNotIsFunction'     , 'assert_not_is_function' },
     { 'assertNotIsThread'       , 'assert_not_is_thread' },
     { 'assertNotIsUserdata'     , 'assert_not_is_userdata' },
@@ -1045,6 +1061,7 @@ local list_of_funcs = {
     { 'assertNotIsBoolean'      , 'assertNotBoolean' },
     { 'assertNotIsNil'          , 'assertNotNil' },
     { 'assertNotIsNaN'          , 'assertNotNaN' },
+    { 'assertNotIsInf'          , 'assertNotInf' },
     { 'assertNotIsFunction'     , 'assertNotFunction' },
     { 'assertNotIsThread'       , 'assertNotThread' },
     { 'assertNotIsUserdata'     , 'assertNotUserdata' },
@@ -1056,6 +1073,7 @@ local list_of_funcs = {
     { 'assertNotIsBoolean'      , 'assert_not_boolean' },
     { 'assertNotIsNil'          , 'assert_not_nil' },
     { 'assertNotIsNaN'          , 'assert_not_nan' },
+    { 'assertNotIsInf'          , 'assert_not_inf' },
     { 'assertNotIsFunction'     , 'assert_not_function' },
     { 'assertNotIsThread'       , 'assert_not_thread' },
     { 'assertNotIsUserdata'     , 'assert_not_userdata' },

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -673,6 +673,18 @@ function M.assertNotIsNil(value)
     end
 end
 
+function M.assertIsNaN(value)
+    if type(value) ~= "number" or value == value then
+        failure("expected: nan, actual: " ..prettystr(value), 2)
+    end
+end
+
+function M.assertNotIsNaN(value)
+    if type(value) == "number" and value ~= value then
+        failure("expected non nan value, received nan", 2)
+    end
+end
+
 function M.assertEquals(actual, expected)
     if type(actual) == 'table' and type(expected) == 'table' then
         if not _is_table_equals(actual, expected) then
@@ -973,6 +985,7 @@ local list_of_funcs = {
     { 'assertIsTable'           , 'assert_is_table' },
     { 'assertIsBoolean'         , 'assert_is_boolean' },
     { 'assertIsNil'             , 'assert_is_nil' },
+    { 'assertIsNaN'             , 'assert_is_nan' },
     { 'assertIsFunction'        , 'assert_is_function' },
     { 'assertIsThread'          , 'assert_is_thread' },
     { 'assertIsUserdata'        , 'assert_is_userdata' },
@@ -983,6 +996,7 @@ local list_of_funcs = {
     { 'assertIsTable'           , 'assertTable' },
     { 'assertIsBoolean'         , 'assertBoolean' },
     { 'assertIsNil'             , 'assertNil' },
+    { 'assertIsNaN'             , 'assertNaN' },
     { 'assertIsFunction'        , 'assertFunction' },
     { 'assertIsThread'          , 'assertThread' },
     { 'assertIsUserdata'        , 'assertUserdata' },
@@ -993,6 +1007,7 @@ local list_of_funcs = {
     { 'assertIsTable'           , 'assert_table' },
     { 'assertIsBoolean'         , 'assert_boolean' },
     { 'assertIsNil'             , 'assert_nil' },
+    { 'assertIsNaN'             , 'assert_nan' },
     { 'assertIsFunction'        , 'assert_function' },
     { 'assertIsThread'          , 'assert_thread' },
     { 'assertIsUserdata'        , 'assert_userdata' },
@@ -1003,6 +1018,7 @@ local list_of_funcs = {
     { 'assertNotIsTable'        , 'assert_not_is_table' },
     { 'assertNotIsBoolean'      , 'assert_not_is_boolean' },
     { 'assertNotIsNil'          , 'assert_not_is_nil' },
+    { 'assertNotIsNaN'          , 'assert_not_is_nan' },
     { 'assertNotIsFunction'     , 'assert_not_is_function' },
     { 'assertNotIsThread'       , 'assert_not_is_thread' },
     { 'assertNotIsUserdata'     , 'assert_not_is_userdata' },
@@ -1013,6 +1029,7 @@ local list_of_funcs = {
     { 'assertNotIsTable'        , 'assertNotTable' },
     { 'assertNotIsBoolean'      , 'assertNotBoolean' },
     { 'assertNotIsNil'          , 'assertNotNil' },
+    { 'assertNotIsNaN'          , 'assertNotNaN' },
     { 'assertNotIsFunction'     , 'assertNotFunction' },
     { 'assertNotIsThread'       , 'assertNotThread' },
     { 'assertNotIsUserdata'     , 'assertNotUserdata' },
@@ -1023,6 +1040,7 @@ local list_of_funcs = {
     { 'assertNotIsTable'        , 'assert_not_table' },
     { 'assertNotIsBoolean'      , 'assert_not_boolean' },
     { 'assertNotIsNil'          , 'assert_not_nil' },
+    { 'assertNotIsNaN'          , 'assert_not_nan' },
     { 'assertNotIsFunction'     , 'assert_not_function' },
     { 'assertNotIsThread'       , 'assert_not_thread' },
     { 'assertNotIsUserdata'     , 'assert_not_userdata' },
@@ -2215,7 +2233,6 @@ end
         self.quitOnError   = options.quitOnError
         self.quitOnFailure = options.quitOnFailure
         self.fname         = options.fname
-
         self.exeCount             = options.exeCount
         self.patternIncludeFilter = options.pattern
         self.patternExcludeFilter = options.exclude
@@ -2253,4 +2270,3 @@ M.SetVerbosity = M.setVerbosity
 
 
 return M
-

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -649,14 +649,26 @@ function M.assertError(f, ...)
     end
 end
 
-function M.assertTrue(value)
+function M.assertIf(value)
     if not value then
+        failure("expected: not false or nil, actual: " ..prettystr(value), 2)
+    end
+end
+
+function M.assertNotIf(value)
+    if value then
+        failure("expected: false or nil, actual: " ..prettystr(value), 2)
+    end
+end
+
+function M.assertTrue(value)
+    if value ~= true then
         failure("expected: true, actual: " ..prettystr(value), 2)
     end
 end
 
 function M.assertFalse(value)
-    if value then
+    if value ~= false then
         failure("expected: false, actual: " ..prettystr(value), 2)
     end
 end
@@ -963,6 +975,8 @@ local list_of_funcs = {
     { 'assertNotEquals'         , 'assert_not_equals' },
     { 'assertAlmostEquals'      , 'assert_almost_equals' },
     { 'assertNotAlmostEquals'   , 'assert_not_almost_equals' },
+    { 'assertIf'                , 'assert_if' },
+    { 'assertNotIf'             , 'assert_not_if' },
     { 'assertTrue'              , 'assert_true' },
     { 'assertFalse'             , 'assert_false' },
     { 'assertStrContains'       , 'assert_str_contains' },

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -733,8 +733,6 @@ end
 -- Help Lua in corner cases like almostEquals(1.1, 1.0, 0.1), which by default
 -- may not work. We need to give a default margin; EPSILON defines the
 -- default value to use for this:
-M.EPSILON = 1E-12
-
 function M.almostEquals( actual, expected, margin )
     margin = margin or M.EPSILON
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -710,10 +710,11 @@ function M.assertEquals(actual, expected)
 end
 
 -- Help Lua in corner cases like almostEquals(1.1, 1.0, 0.1), which by default
--- may not work. We need to give margin a small boost; EPSILON defines the
+-- may not work. We need to give a default margin; EPSILON defines the
 -- default value to use for this:
-local EPSILON = 1E-11
-function M.almostEquals( actual, expected, margin, margin_boost )
+local M.EPSILON = 1E-12
+function M.almostEquals( actual, expected, margin )
+    margin = margin or M.EPSILON
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
             prettystr(actual), prettystr(expected), prettystr(margin))
@@ -721,8 +722,7 @@ function M.almostEquals( actual, expected, margin, margin_boost )
     if margin < 0 then
         error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
     end
-    local realmargin = margin + (margin_boost or EPSILON)
-    return math.abs(expected - actual) <= realmargin
+    return math.abs(expected - actual) <= margin
 end
 
 function M.assertAlmostEquals( actual, expected, margin )


### PR DESCRIPTION
[second attempt to make a clean pull request, hope it will be fine]
As discussed with Philippe Fremy by email, I do a pull request for features I needed and proved to be extremely useful to test codes, including LuaJIT itself and scientific codes.

Modified:
- assertTrue/False to be strict (essential), user can still do lazy False (i.e. not x instead of x == false) or use the renamed version hereafter.
- Non-strict assertTrue/False have been renamed assertIf/assertNotIf after discussion with NiteHawk.
- Remove extra margin in assertAlmostEquals, as it prevents any serious use in numerical codes (its main purpose, right?). Moreover, it is _not_ expected from user point of view to have it's own margin being modified in the back (and fails to check correctly for bugs...). EPSILON is used as default margin for common cases if none is provided. Removing the old behaviour extends the flexibility of assertAlmostEquals since it allows to check for absolute error vs expected, absolute error minus expected versus zero, relative error vs expected and relative error divided by expected versus one, and checked within the user defined margin (four common cases mostly used in numerical tests).

Added:
- assertIsNaN and variants (true check for numerical NaN).
- assertIsInf and variants (check for numerical ±Inf). For signed checks of infinity, assertEquals is the right tool. For signed checks of zero, assertEquals is also the right tool (i.e. check 1/x versus ±inf).
- -x, --exclude PATTERN, works as -p but filter out tests matching the pattern. It improves the selection flexibility as Lua patterns are not expressive to negate matching. This filter out comes after the -p filter if any: all-tests -> selected-tests -> selected-tests - excluded tests -> run-tests. 
- -c, --count NUM to run NUM times the tests and ensure testing also the JITed version of the code (essential with LuaJIT). setUp and tearDown must be part of the loop to preserve referential transparency of unit tests. The failure message displays also the iteration number where an assertion failed if this option is specified.

Typical use of added extensions assuming that TestPerf are performance tests (longer to run):
./luajit testsuite.lua -x TestPerf # only regression tests
./luajit testsuite.lua -p TestPerf # only performance tests
./luajit testsuite.lua -c 4 -x TestPerf # test referential transparency of regression tests
./luajit testsuite.lua -c 100 -x TestPerf # test JITed version of regression tests

Last use is essential to check consistency between interpreted and compiled code with LuaJIT. I found few bugs and inconsistencies with this feature!

Do not hesitate to ask me information to clarify any points, especially for the documentation. I have motivated all my proposal through email discussions with Philippe and NiteHawk. As a general comment, the philosophy of the proposal is to improve strictness of the unit tests (never relax it!) and flexibility of the framework (in that order).

Best,
Laurent.
