### PR TITLE
Extend Travis CI to test "single" precision Lua configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ env:
   global:
     - LUAROCKS=2.2.2
   matrix:
-    - LUA=lua5.1
-    - LUA=lua5.2
-    - LUA=lua5.3
+    - LUA=lua5.1  LUANUMBER=double
+    - LUA=lua5.1  LUANUMBER=float
+    - LUA=lua5.2  LUANUMBER=double
+    - LUA=lua5.2  LUANUMBER=float
+    - LUA=lua5.3  LUANUMBER=double
+    - LUA=lua5.3  LUANUMBER=float
     - LUA=luajit     # latest stable version (2.0.x)
     - LUA=luajit2.0  # current head of 2.0 branch
     - LUA=luajit2.1  # current head of 2.1 branch

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -700,8 +700,13 @@ end
 
 -- Help Lua in corner cases like almostEquals(1.1, 1.0, 0.1), which by default
 -- may not work. We need to give margin a small boost; EPSILON defines the
--- default value to use for this:
-local EPSILON = 1E-11
+-- default value to use for this. Since Lua may be compiled with different
+-- numeric precisions (single vs. double), we try to select a useful default:
+local EPSILON = math.exp(-51 * math.log(2)) -- 2 * (2^-52, machine epsilon for "double") ~4.44E-16
+if math.abs(1.1 - 1 - 0.1) > EPSILON then
+    -- rounding error is above EPSILON, assume single precision
+    EPSILON = math.exp(-22 * math.log(2)) -- 2 * (2^-23, machine epsilon for "float") ~2.38E-07
+end
 function M.almostEquals( actual, expected, margin, margin_boost )
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',


### PR DESCRIPTION
This pull request follows up on the suggestion (in #67) to test Lua configurations with 32-bit floats. It adds three new entries to the build matrix that will use customized versions of Lua (5.1, 5.2 and 5.3) where the `LUA_NUMBER` type gets modified accordingly.