### PR TITLE
Suggest alternative approach for dealing with numerical assertions

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -24,6 +24,7 @@ assertEquals( expected, actual ).
 M.ORDER_ACTUAL_EXPECTED = true
 M.PRINT_TABLE_REF_IN_ERROR_MSG = false
 M.TABLE_EQUALS_KEYBYCONTENT = true
+M.ALMOST_EQUALS_USES_EPSILON = true
 M.LINE_LENGTH=80
 
 --[[ M.EPSILON is meant to help with Lua's floating point math in simple corner
@@ -721,7 +722,12 @@ function M.almostEquals( actual, expected, margin, margin_boost )
     if margin < 0 then
         error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
     end
-    local realmargin = margin + (margin_boost or M.EPSILON)
+    local realmargin
+    if M.ALMOST_EQUALS_USES_EPSILON then
+        realmargin = margin + (margin_boost or M.EPSILON)
+    else
+        realmargin = margin + (margin_boost or 0)
+    end
     return math.abs(expected - actual) <= realmargin
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -26,6 +26,22 @@ M.PRINT_TABLE_REF_IN_ERROR_MSG = false
 M.TABLE_EQUALS_KEYBYCONTENT = true
 M.LINE_LENGTH=80
 
+--[[ M.EPSILON is meant to help with Lua's floating point math in simple corner
+cases like almostEquals(1.1-0.1, 1), which may not work as-is (e.g. on numbers
+with rational binary representation) if the user doesn't provide some explicit
+error margin.
+The default margin used by almostEquals() in such cases is M.EPSILON; and since
+Lua may be compiled with different numeric precisions (single vs. double), we
+try to select a useful default for it dynamically. Note: If the initial value
+is not acceptable, it can be changed by the user to better suit specific needs.
+See also: https://en.wikipedia.org/wiki/Machine_epsilon
+]]
+M.EPSILON = 2^-52 -- = machine epsilon for "double", ~2.22E-16
+if math.abs(1.1 - 1 - 0.1) > M.EPSILON then
+    -- rounding error is above EPSILON, assume single precision
+    M.EPSILON = 2^-23 -- = machine epsilon for "float", ~1.19E-07
+end
+
 -- set this to false to debug luaunit
 local STRIP_LUAUNIT_FROM_STACKTRACE=true
 
@@ -697,15 +713,6 @@ function M.assertEquals(actual, expected)
     end
 end
 
--- Help Lua in corner cases like almostEquals(1.1, 1.0, 0.1), which by default
--- may not work. We need to give margin a small boost; EPSILON defines the
--- default value to use for this. Since Lua may be compiled with different
--- numeric precisions (single vs. double), we try to select a useful default:
-local EPSILON = math.exp(-51 * math.log(2)) -- 2 * (2^-52, machine epsilon for "double") ~4.44E-16
-if math.abs(1.1 - 1 - 0.1) > EPSILON then
-    -- rounding error is above EPSILON, assume single precision
-    EPSILON = math.exp(-22 * math.log(2)) -- 2 * (2^-23, machine epsilon for "float") ~2.38E-07
-end
 function M.almostEquals( actual, expected, margin, margin_boost )
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
@@ -714,7 +721,7 @@ function M.almostEquals( actual, expected, margin, margin_boost )
     if margin < 0 then
         error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
     end
-    local realmargin = margin + (margin_boost or EPSILON)
+    local realmargin = margin + (margin_boost or M.EPSILON)
     return math.abs(expected - actual) <= realmargin
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -750,26 +750,20 @@ local function margin(limit, epsilons)
 end
 M.private.margin = margin
 
-function M.almostEquals( actual, expected, margin, margin_boost )
-    if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
-        error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
-            prettystr(actual), prettystr(expected), prettystr(margin))
+local function almostEquals(actual, expected, limit, epsilons)
+    if type(actual) ~= 'number' or type(expected) ~= 'number' then
+        error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s',
+            prettystr(actual), prettystr(expected))
     end
-    if margin < 0 then
-        error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
-    end
-    local realmargin
     if M.ALMOST_EQUALS_USES_EPSILON then
-        realmargin = margin + (margin_boost or M.EPSILON)
-    else
-        realmargin = margin + (margin_boost or 0)
+        epsilons = epsilons or 1 -- default to M.EPSILON
     end
-    return math.abs(expected - actual) <= realmargin
+    return math.abs(expected - actual) <= margin(limit, epsilons)
 end
 
-function M.assertAlmostEquals( actual, expected, margin )
+function M.assertAlmostEquals( actual, expected, margin, epsilons )
     -- check that two floats are close by margin
-    if not M.almostEquals(actual, expected, margin) then
+    if not almostEquals(actual, expected, margin, epsilons) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end
@@ -793,9 +787,9 @@ function M.assertNotEquals(actual, expected)
     fail_fmt(2, 'Received the not expected value: %s', prettystr(actual))
 end
 
-function M.assertNotAlmostEquals( actual, expected, margin )
+function M.assertNotAlmostEquals( actual, expected, margin, epsilons )
     -- check that two floats are not close by margin
-    if M.almostEquals(actual, expected, margin) then
+    if almostEquals(actual, expected, margin, epsilons) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -798,6 +798,30 @@ function M.assertNotAlmostEquals( actual, expected, margin, epsilons )
     end
 end
 
+-- assert "absolute" error between actual and expected is within given boundary
+function M.assertAbsErrorWithin(actual, expected, limit, epsilons)
+    -- values for limit and absolute error
+    local lim, e = margin(limit, epsilons), actual - expected
+
+    if math.abs(e) > lim then
+        fail_fmt(2, 'Absolute error exceeded\n' ..
+                    'Actual: %s, expected: %s with margin of %s; delta: %s',
+                    actual, expected, lim, math.abs(e) - lim)
+    end
+end
+
+-- assert "absolute" error between actual and expected NOT within given boundary
+function M.assertNotAbsErrorWithin(actual, expected, limit, epsilons)
+    -- values for limit and absolute error
+    local lim, e = margin(limit, epsilons), actual - expected
+
+    if math.abs(e) <= lim then
+        fail_fmt(2, 'Absolute error NOT exceeded\n' ..
+                    'Actual: %s, expected: %s with margin above %s; delta: %s',
+                    actual, expected, lim, lim - math.abs(e))
+    end
+end
+
 function M.assertStrContains( str, sub, useRe )
     -- this relies on lua string.find function
     -- a string always contains the empty string

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -714,6 +714,42 @@ function M.assertEquals(actual, expected)
     end
 end
 
+--[[ helper function to determine an error margin
+
+`limit` represents an "absolute" value. For user's convenience it's also
+possible to pass `true` instead, to select M.EPSILON as the default margin.
+(i.e. margin(true) will return M.EPSILON)
+
+`epsilons` is a multiplicative factor that specifies a boundary in terms of
+"multiples of M.EPSILON". (This may be useful to express error margins relative
+to the numeric precision that the underlying Lua implementation offers.)
+
+The two parameters default to zero, i.e. margin(nil, nil) will return 0. If both
+are specified, the resulting values will get added (= sum up). This gives users
+a simple way to specify a larger "absolute" value plus some compensation for
+small rounding errors - e.g. margin(1E-4, 1) would return 1E-4 + M.EPSILON.
+
+margin()            0
+margin(1E-5)        1E-5
+margin(1E-5, 3)     1E-5 + 3 * M.EPSILON
+margin(true)        M.EPSILON
+margin(nil, 1)      M.EPSILON
+margin(true, 0.5)   M.EPSILON + 0.5 * M.EPSILON  = M.EPSILON * 1.5
+]]
+local function margin(limit, epsilons)
+    if limit == true then
+        limit = M.EPSILON
+    elseif limit == nil then
+        limit = 0
+    end
+    local result = limit + (epsilons or 0) * M.EPSILON
+    if result < 0 then
+        error('margin must not be negative, resulting value was ' .. result, 2)
+    end
+    return result
+end
+M.private.margin = margin
+
 function M.almostEquals( actual, expected, margin, margin_boost )
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -822,6 +822,44 @@ function M.assertNotAbsErrorWithin(actual, expected, limit, epsilons)
     end
 end
 
+-- assert "relative" error between actual and expected is within given boundary
+function M.assertRelErrorWithin(actual, expected, limit, epsilons)
+    -- relative error is affected by order of arguments!
+    if not M.ORDER_ACTUAL_EXPECTED then
+        expected, actual = actual, expected
+    end
+    -- values for limit and relative error
+    local lim, e = margin(limit, epsilons), actual / expected - 1
+
+    if math.abs(e) == math.huge then
+        error("relative error is 'inf', don't try to use 'expected' == 0")
+    end
+    if math.abs(e) > lim then
+        fail_fmt(2, 'Relative error exceeded\n' ..
+                    'Actual: %s, expected: %s with margin of %s; delta: %s',
+                    actual, expected, lim, math.abs(e) - lim)
+    end
+end
+
+-- assert "relative" error between actual and expected NOT within given boundary
+function M.assertNotRelErrorWithin(actual, expected, limit, epsilons)
+    -- relative error is affected by order of arguments!
+    if not M.ORDER_ACTUAL_EXPECTED then
+        expected, actual = actual, expected
+    end
+    -- values for limit and relative error
+    local lim, e = margin(limit, epsilons), actual / expected - 1
+
+    if math.abs(e) == math.huge then
+        error("relative error is 'inf', don't try to use 'expected' == 0")
+    end
+    if math.abs(e) <= lim then
+        fail_fmt(2, 'Relative error NOT exceeded\n' ..
+                    'Actual: %s, expected: %s with margin above %s; delta: %s',
+                    actual, expected, lim, lim - math.abs(e))
+    end
+end
+
 function M.assertStrContains( str, sub, useRe )
     -- this relies on lua string.find function
     -- a string always contains the empty string

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -746,6 +746,8 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
     end
 
     function TestLuaUnitAssertions:test_assertAlmostEquals()
+        local config_saved = lu.ALMOST_EQUALS_USES_EPSILON
+
         lu.assertAlmostEquals( 1, 1, 0.1 )
         lu.assertAlmostEquals( 1, 1, 0 ) -- zero margin
 
@@ -753,6 +755,12 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         lu.assertAlmostEquals( -1, -1.1, 0.2 )
         lu.assertAlmostEquals( 0.1, -0.1, 0.3 )
 
+        lu.ALMOST_EQUALS_USES_EPSILON = false
+        -- With no additional margin (epsilon), these are expected to FAIL
+        assertFailure( lu.assertAlmostEquals, 1, 1.1, 0.1 )
+        assertFailure( lu.assertAlmostEquals, -1, -1.1, 0.1 )
+
+        lu.ALMOST_EQUALS_USES_EPSILON = true
         lu.assertAlmostEquals( 1, 1.1, 0.1 )
         lu.assertAlmostEquals( -1, -1.1, 0.1 )
         lu.assertAlmostEquals( 0.1, -0.1, 0.2 )
@@ -763,6 +771,8 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, nil, 0 )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, nil, 1, 0 )
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertAlmostEquals, 1, 1.1, -0.1 )
+
+        lu.ALMOST_EQUALS_USES_EPSILON = config_saved
     end
 
     function TestLuaUnitAssertions:test_assertNotEquals()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -783,7 +783,6 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
 
         assertFailure( lu.assertAlmostEquals, 1, 1.11, 0.1 )
         assertFailure( lu.assertAlmostEquals, -1, -1.11, 0.1 )
-        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, 1, nil )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, nil, 0 )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, nil, 1, 0 )
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertAlmostEquals, 1, 1.1, -0.1 )
@@ -830,7 +829,6 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
 
         assertFailure( lu.assertNotAlmostEquals, 1, 1.11, 0.2 )
         assertFailure( lu.assertNotAlmostEquals, -1, -1.11, 0.2 )
-        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, -1, 1, nil )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, -1, nil, 0 )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, nil, 1, 0 )
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertNotAlmostEquals, 1, 1.1, -0.1 )

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -642,6 +642,22 @@ TestLuaUnitUtilities = { __class__ = 'TestLuaUnitUtilities' }
 
     end
 
+    function TestLuaUnitUtilities:testMargin()
+        local eps = lu.EPSILON
+
+        lu.assertEquals(lu.private.margin(), 0)
+        lu.assertEquals(lu.private.margin(true), eps)
+        lu.assertEquals(lu.private.margin(nil, 1), eps)
+        lu.assertEquals(lu.private.margin(1E-5), 1E-5)
+        lu.assertEquals(lu.private.margin(1E-5, 3), 1E-5 + 3 * eps)
+        lu.assertEquals(lu.private.margin(true, 0.5), 1.5 * eps)
+
+        lu.assertErrorMsgContains('margin must not be negative',
+                                  lu.private.margin, -1E-20)
+        lu.assertErrorMsgContains('margin must not be negative',
+                                  lu.private.margin, nil, -0.01)
+    end
+
 ------------------------------------------------------------------
 --
 --                        Outputter Tests

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -834,6 +834,38 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertNotAlmostEquals, 1, 1.1, -0.1 )
     end
 
+    function TestLuaUnitAssertions:test_assertAbsErrorWithin()
+        -- with no additional epsilon, these are expected to FAIL due to rounding
+        -- (this checks that a user-supplied margin gets used unmodified)
+        assertFailure( lu.assertAbsErrorWithin, 1.1, 1.0, 0.1 )     -- explicit margin
+        assertFailure( lu.assertAbsErrorWithin, 1.1 - 1.0, 0.1 )    -- implicit zero margin
+        assertFailure( lu.assertAbsErrorWithin, 1.1 - 1.0, 0.1, 0 ) -- explicit zero margin
+        -- explicitly "boost" margin to make tests PASS
+        lu.assertAbsErrorWithin( 1.1, 1.0, 0.1, 1 )         -- 1 * EPSILON
+        lu.assertAbsErrorWithin( 1.1 - 1.0, 0.1, nil, 1 )   -- 1 * EPSILON
+        lu.assertAbsErrorWithin( 1.1 - 1.0, 0.1, true )     -- default margin = EPSILON
+
+        lu.assertAbsErrorWithin(math.deg(math.pi / 3), 60, 0, 32) -- 32 * EPSILON
+        lu.assertAbsErrorWithin(math.sqrt(2) * math.sqrt(2), 2, 0, 2) -- 2 * EPSILON
+    end
+
+    function TestLuaUnitAssertions:test_assertNotAbsErrorWithin()
+        -- these are expected to PASS due to rounding errors
+        lu.assertNotAbsErrorWithin( 1.1, 1.0, 0.1 )     -- explicit margin
+        lu.assertNotAbsErrorWithin( 1.1 - 1.0, 0.1 )    -- implicit zero margin
+        lu.assertNotAbsErrorWithin( 1.1 - 1.0, 0.1, 0 ) -- explicit zero margin
+        -- explicitly "boost" margin to make tests FAIL
+        assertFailure( lu.assertNotAbsErrorWithin, 1.1, 1.0, 0.1, 1 )       -- 1 * EPSILON
+        assertFailure( lu.assertNotAbsErrorWithin, 1.1 - 1.0, 0.1, nil, 1 ) -- 1 * EPSILON
+        assertFailure( lu.assertNotAbsErrorWithin, 1.1 - 1.0, 0.1, true )   -- default margin = EPSILON
+
+        if lu.EPSILON < 1E-15 then
+            -- these tests won't fail when testing with single precision
+            lu.assertNotAbsErrorWithin(math.deg(math.pi / 3), 60, 0, 31)
+            lu.assertNotAbsErrorWithin(math.sqrt(2) * math.sqrt(2), 2, true) -- 1 * EPSILON
+        end
+    end
+
     function TestLuaUnitAssertions:test_assertNotEqualsDifferentTypes2()
         lu.assertNotEquals( 2, "abc" )
     end


### PR DESCRIPTION
This pull request is related to ideas introduced in #66 and #68. @ldeniau pointed out that our existing `almostEquals()` function has some shortcomings when it comes to 'scientific' testing of numerical errors / precision.

To address these concerns, some changes to `almostEquals()` have been suggested - most notably the ability to prevent any modification of the user-provided error limit ("margin"). I've been rethinking this over the weekend and would like to take it another step further: Introduce a new set of functions that deal with "numerical error assertions".

- `assertAbsErrorWithin()` and `assertNotAbsErrorWithin()` test for _absolute_ error/margin
- `assertRelErrorWithin()` and `assertNotRelErrorWithin()` test for _relative_ error/margin

I'd like your opinion on this.

Regards, NiteHawk