### PR TITLE
Finalize on #68

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -74,10 +74,10 @@ Options:
   -n, --name NAME:        For junit only, mandatory name of xml file
   -c, --count NUM:        Execute all tests NUM times, e.g. to trig the JIT
   -p, --pattern PATTERN:  Execute all test names matching the Lua PATTERN
-                          May be repeated to include severals patterns
+                          May be repeated to include several patterns
                           Make sure you escape magic chars like +? with %
   -x, --exclude PATTERN:  Exclude all test names matching the Lua PATTERN
-                          May be repeated to include severals patterns
+                          May be repeated to exclude several patterns
                           Make sure you escape magic chars like +? with %
   testname1, testname2, ... : tests to run in the form of testFunction,
                               TestClass or TestClass.testMethod

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -866,8 +866,10 @@ function M.assertAlmostEquals( actual, expected, margin )
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end
-        fail_fmt(2, 'Values are not almost equal\nExpected: %s with margin of %s, received: %s',
-                 expected, margin, actual)
+        local delta = math.abs(actual - expected) - margin
+        fail_fmt(2, 'Values are not almost equal\n' ..
+                    'Actual: %s, expected: %s with margin of %s; delta: %s',
+                    actual, expected, margin, delta)
     end
 end
 
@@ -893,8 +895,10 @@ function M.assertNotAlmostEquals( actual, expected, margin )
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
         end
-        fail_fmt(2, 'Values are almost equal\nExpected: %s with a difference above margin of %s, received: %s',
-                 expected, margin, actual)
+        local delta = margin - math.abs(actual - expected)
+        fail_fmt(2, 'Values are almost equal\nActual: %s, expected: %s' ..
+                    ' with a difference above margin of %s; delta: %s',
+                    actual, expected, margin, delta)
     end
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -848,7 +848,7 @@ function M.assertEquals(actual, expected)
     end
 end
 
-function M.almostEquals( actual, expected, margin, margin_boost )
+function M.almostEquals( actual, expected, margin )
     if type(actual) ~= 'number' or type(expected) ~= 'number' or type(margin) ~= 'number' then
         error_fmt(3, 'almostEquals: must supply only number arguments.\nArguments supplied: %s, %s, %s',
             prettystr(actual), prettystr(expected), prettystr(margin))
@@ -856,12 +856,12 @@ function M.almostEquals( actual, expected, margin, margin_boost )
     if margin < 0 then
         error('almostEquals: margin must not be negative, current value is ' .. margin, 3)
     end
-    local realmargin = margin + (margin_boost or M.EPSILON)
-    return math.abs(expected - actual) <= realmargin
+    return math.abs(expected - actual) <= margin
 end
 
 function M.assertAlmostEquals( actual, expected, margin )
     -- check that two floats are close by margin
+    margin = margin or M.EPSILON
     if not M.almostEquals(actual, expected, margin) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected
@@ -888,6 +888,7 @@ end
 
 function M.assertNotAlmostEquals( actual, expected, margin )
     -- check that two floats are not close by margin
+    margin = margin or M.EPSILON
     if M.almostEquals(actual, expected, margin) then
         if not M.ORDER_ACTUAL_EXPECTED then
             expected, actual = actual, expected

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1712,21 +1712,23 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
     end 
 
     function TestLuaUnitErrorMsg:test_assertAlmostEqualsMsg()
-        assertFailureEquals('Values are not almost equal\nExpected: 1 with margin of 0.1, received: 2', lu.assertAlmostEquals, 2, 1, 0.1 )
+        assertFailureEquals('Values are not almost equal\nActual: 2, expected: 1 with margin of 0.1; delta: 0.9', lu.assertAlmostEquals, 2, 1, 0.1 )
     end
 
     function TestLuaUnitErrorMsg:test_assertAlmostEqualsOrderReversedMsg()
         lu.ORDER_ACTUAL_EXPECTED = false
-        assertFailureEquals('Values are not almost equal\nExpected: 2 with margin of 0.1, received: 1', lu.assertAlmostEquals, 2, 1, 0.1 )
+        assertFailureEquals('Values are not almost equal\nActual: 1, expected: 2 with margin of 0.1; delta: 0.9', lu.assertAlmostEquals, 2, 1, 0.1 )
     end
 
     function TestLuaUnitErrorMsg:test_assertNotAlmostEqualsMsg()
-        assertFailureEquals('Values are almost equal\nExpected: 1 with a difference above margin of 0.2, received: 1.1', lu.assertNotAlmostEquals, 1.1, 1, 0.2 )
+        -- single precision math Lua won't output an "exact" delta (0.1) here, so we do a partial match
+        assertFailureContains('Values are almost equal\nActual: 1.1, expected: 1 with a difference above margin of 0.2; delta: ', lu.assertNotAlmostEquals, 1.1, 1, 0.2 )
     end
 
-    function TestLuaUnitErrorMsg:test_assertNotAlmostEqualsMsg()
+    function TestLuaUnitErrorMsg:test_assertNotAlmostEqualsOrderReversedMsg()
+        -- single precision math Lua won't output an "exact" delta (0.1) here, so we do a partial match
         lu.ORDER_ACTUAL_EXPECTED = false
-        assertFailureEquals('Values are almost equal\nExpected: 1.1 with a difference above margin of 0.2, received: 1', lu.assertNotAlmostEquals, 1.1, 1, 0.2 )
+        assertFailureContains('Values are almost equal\nActual: 1, expected: 1.1 with a difference above margin of 0.2; delta: ', lu.assertNotAlmostEquals, 1.1, 1, 0.2 )
     end
 
     function TestLuaUnitErrorMsg:test_assertNotEqualsMsg()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -828,19 +828,31 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
 
     function TestLuaUnitAssertions:test_assertAlmostEquals()
         lu.assertAlmostEquals( 1, 1, 0.1 )
+        lu.assertAlmostEquals( 1, 1 ) -- default margin (= M.EPSILON)
         lu.assertAlmostEquals( 1, 1, 0 ) -- zero margin
+        assertFailure( lu.assertAlmostEquals, 0, lu.EPSILON, 0 ) -- zero margin
 
         lu.assertAlmostEquals( 1, 1.1, 0.2 )
         lu.assertAlmostEquals( -1, -1.1, 0.2 )
         lu.assertAlmostEquals( 0.1, -0.1, 0.3 )
-
-        lu.assertAlmostEquals( 1, 1.1, 0.1 )
-        lu.assertAlmostEquals( -1, -1.1, 0.1 )
         lu.assertAlmostEquals( 0.1, -0.1, 0.2 )
+
+        -- Due to rounding errors, these user-supplied margins are too small.
+        -- The tests should respect them, and so are required to fail.
+        assertFailure( lu.assertAlmostEquals, 1, 1.1, 0.1 )
+        assertFailure( lu.assertAlmostEquals, -1, -1.1, 0.1 )
+        -- Check that an explicit zero margin gets respected too
+        assertFailure( lu.assertAlmostEquals, 1.1 - 1, 0.1, 0 )
+        assertFailure( lu.assertAlmostEquals, -1 - (-1.1), 0.1, 0 )
+        -- Tests pass when adding M.EPSILON, either explicitly or implicitly
+        lu.assertAlmostEquals( 1, 1.1, 0.1 + lu.EPSILON)
+        lu.assertAlmostEquals( 1.1 - 1, 0.1 )
+        lu.assertAlmostEquals( -1, -1.1, 0.1 + lu.EPSILON )
+        lu.assertAlmostEquals( -1 - (-1.1), 0.1 )
 
         assertFailure( lu.assertAlmostEquals, 1, 1.11, 0.1 )
         assertFailure( lu.assertAlmostEquals, -1, -1.11, 0.1 )
-        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, 1, nil )
+        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, 1, "foobar" )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, -1, nil, 0 )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertAlmostEquals, nil, 1, 0 )
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertAlmostEquals, 1, 1.1, -0.1 )
@@ -873,7 +885,9 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
 
     function TestLuaUnitAssertions:test_assertNotAlmostEquals()
         lu.assertNotAlmostEquals( 1, 1.2, 0.1 )
+        lu.assertNotAlmostEquals( 1, 1.01 ) -- default margin (= M.EPSILON)
         lu.assertNotAlmostEquals( 1, 1.01, 0 ) -- zero margin
+        lu.assertNotAlmostEquals( 0, lu.EPSILON, 0 ) -- zero margin
 
         lu.assertNotAlmostEquals( 1, 1.3, 0.2 )
         lu.assertNotAlmostEquals( -1, -1.3, 0.2 )
@@ -883,9 +897,22 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         lu.assertNotAlmostEquals( -1, -1.1, 0.09 )
         lu.assertNotAlmostEquals( 0.1, -0.1, 0.11 )
 
+        -- Due to rounding errors, these user-supplied margins are too small.
+        -- The tests should respect them, and so are expected to pass.
+        lu.assertNotAlmostEquals( 1, 1.1, 0.1 )
+        lu.assertNotAlmostEquals( -1, -1.1, 0.1 )
+        -- Check that an explicit zero margin gets respected too
+        lu.assertNotAlmostEquals( 1.1 - 1, 0.1, 0 )
+        lu.assertNotAlmostEquals( -1 - (-1.1), 0.1, 0 )
+        -- Tests fail when adding M.EPSILON, either explicitly or implicitly
+        assertFailure( lu.assertNotAlmostEquals, 1, 1.1, 0.1 + lu.EPSILON)
+        assertFailure( lu.assertNotAlmostEquals, 1.1 - 1, 0.1 )
+        assertFailure( lu.assertNotAlmostEquals, -1, -1.1, 0.1 + lu.EPSILON )
+        assertFailure( lu.assertNotAlmostEquals, -1 - (-1.1), 0.1 )
+
         assertFailure( lu.assertNotAlmostEquals, 1, 1.11, 0.2 )
         assertFailure( lu.assertNotAlmostEquals, -1, -1.11, 0.2 )
-        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, -1, 1, nil )
+        lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, -1, 1, "foobar" )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, -1, nil, 0 )
         lu.assertErrorMsgContains( "must supply only number arguments", lu.assertNotAlmostEquals, nil, 1, 0 )
         lu.assertErrorMsgContains( "margin must not be negative", lu.assertNotAlmostEquals, 1, 1.1, -0.1 )


### PR DESCRIPTION
Lack of feedback (and rebasing) have caused pull request #68 to be in a more or less abandoned state. Merging this would integrate the remaining `almostEquals()` change (i.e. the removal of an implicit `marginBoost`), and allow to close the PR.

Note: Due to rounding errors, this **might break existing test cases**. The internal tests have been adjusted accordingly, but we still might want to advise users that they may have to replace `assertAlmostEquals(a, b, margin)` with `assertAlmostEquals(b - a, margin)` in some cases. The latter is "safe" in the sense that it still applies the default `EPSILON` (see also https://github.com/bluebird75/luaunit/pull/68#issuecomment-258392921).

Regards, NiteHawk