### PR TITLE
Use appveyor cache

### DIFF
--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -19,12 +19,18 @@ set LUA="C:\Program Files (x86)\Lua\5.1\lua.exe"
 goto :EOF
 
 :lua51
+@echo off
 if NOT "%LUAENV%"=="lua51" goto lua52
 echo Setting up Lua 5.1 ...
-@echo on
-curl -fLsS -o %ZIP_51% http://sourceforge.net/projects/luabinaries/files/%VER_51%/Tools%%20Executables/%ZIP_51%/download
-unzip %ZIP_51%
-set LUA=lua5.1.exe
+if NOT EXIST "lua51\lua5.1.exe" (
+	@echo on
+    echo Fetching Lua v5.1 from internet
+	curl -fLsS -o %ZIP_51% http://sourceforge.net/projects/luabinaries/files/%VER_51%/Tools%%20Executables/%ZIP_51%/download
+	unzip -d lua51 %ZIP_51%
+) else (
+    echo Using cached version of Lua v5.1
+)
+set LUA="lua51\lua5.1.exe"
 @echo off
 goto :EOF
 

--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -77,11 +77,19 @@ goto :EOF
 :luajit
 if NOT "%LUAENV%"=="luajit20" goto luajit21
 echo Setting up LuaJIT 2.0 ...
-call %~dp0install-luajit.cmd LuaJIT-2.0.4 luajit20
+if NOT EXIST "luajit20\luajit.exe" (
+    call %~dp0install-luajit.cmd LuaJIT-2.0.4 luajit20
+) else (
+    echo Using cached version of LuaJIT 2.0
+)
 set LUA=luajit20\luajit.exe
 goto :EOF
 
 :luajit21
 echo Setting up LuaJIT 2.1 ...
-call %~dp0install-luajit.cmd LuaJIT-2.1.0-beta2 luajit21
+if NOT EXIST "luajit21\luajit.exe" (
+    call %~dp0install-luajit.cmd LuaJIT-2.1.0-beta2 luajit21
+) else (
+    echo Using cached version of LuaJIT 2.1
+)
 set LUA=luajit21\luajit.exe

--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -23,34 +23,48 @@ goto :EOF
 if NOT "%LUAENV%"=="lua51" goto lua52
 echo Setting up Lua 5.1 ...
 if NOT EXIST "lua51\lua5.1.exe" (
-	@echo on
+    @echo on
     echo Fetching Lua v5.1 from internet
-	curl -fLsS -o %ZIP_51% http://sourceforge.net/projects/luabinaries/files/%VER_51%/Tools%%20Executables/%ZIP_51%/download
-	unzip -d lua51 %ZIP_51%
+    curl -fLsS -o %ZIP_51% http://sourceforge.net/projects/luabinaries/files/%VER_51%/Tools%%20Executables/%ZIP_51%/download
+    unzip -d lua51 %ZIP_51%
 ) else (
     echo Using cached version of Lua v5.1
 )
-set LUA="lua51\lua5.1.exe"
+set LUA=lua51\lua5.1.exe
 @echo off
 goto :EOF
 
 :lua52
+@echo off
 if NOT "%LUAENV%"=="lua52" goto lua53
 echo Setting up Lua 5.2 ...
+if NOT EXIST "lua52\lua52.exe" (
+    @echo on
+    echo Fetching Lua v5.2 from internet
+    curl -fLsS -o %ZIP_52% http://sourceforge.net/projects/luabinaries/files/%VER_52%/Tools%%20Executables/%ZIP_52%/download
+    unzip -d lua52 %ZIP_52%
+) else (
+    echo Using cached version of Lua v5.2
+)
 @echo on
-curl -fLsS -o %ZIP_52% http://sourceforge.net/projects/luabinaries/files/%VER_52%/Tools%%20Executables/%ZIP_52%/download
-unzip %ZIP_52%
-set LUA=lua52.exe
+set LUA=lua52\lua52.exe
 @echo off
 goto :EOF
 
 :lua53
+@echo off
 if NOT "%LUAENV%"=="lua53" goto luajit
 echo Setting up Lua 5.3 ...
+if NOT EXIST "lua53\lua53.exe" (
+    @echo on
+    echo Fetching Lua v5.3 from internet
+    curl -fLsS -o %ZIP_53% http://sourceforge.net/projects/luabinaries/files/%VER_53%/Tools%%20Executables/%ZIP_53%/download
+    unzip -d lua53 %ZIP_53%
+) else (
+    echo Using cached version of Lua v5.3
+)
 @echo on
-curl -fLsS -o %ZIP_53% http://sourceforge.net/projects/luabinaries/files/%VER_53%/Tools%%20Executables/%ZIP_53%/download
-unzip %ZIP_53%
-set LUA=lua53.exe
+set LUA=lua53\lua53.exe
 @echo off
 goto :EOF
 

--- a/.appveyor/install-lua.cmd
+++ b/.appveyor/install-lua.cmd
@@ -10,10 +10,16 @@ set ZIP_52=lua-%VER_52%_Win32_bin.zip
 set ZIP_53=lua-%VER_53%_Win32_bin.zip
 
 :cinst
+@echo off
 if NOT "%LUAENV%"=="cinst" goto lua51
 echo Chocolatey install of Lua ...
-@echo on
-cinst lua
+if NOT EXIST "C:\Program Files (x86)\Lua\5.1\lua.exe" (
+    @echo on
+    cinst lua
+) else (
+    @echo on
+    echo Using cached version of Lua
+)
 set LUA="C:\Program Files (x86)\Lua\5.1\lua.exe"
 @echo off
 goto :EOF
@@ -71,11 +77,11 @@ goto :EOF
 :luajit
 if NOT "%LUAENV%"=="luajit20" goto luajit21
 echo Setting up LuaJIT 2.0 ...
-call %~dp0install-luajit.cmd LuaJIT-2.0.4
-set LUA=luajit.exe
+call %~dp0install-luajit.cmd LuaJIT-2.0.4 luajit20
+set LUA=luajit20\luajit.exe
 goto :EOF
 
 :luajit21
 echo Setting up LuaJIT 2.1 ...
-call %~dp0install-luajit.cmd LuaJIT-2.1.0-beta2
-set LUA=luajit.exe
+call %~dp0install-luajit.cmd LuaJIT-2.1.0-beta2 luajit21
+set LUA=luajit21\luajit.exe

--- a/.appveyor/install-luajit.cmd
+++ b/.appveyor/install-luajit.cmd
@@ -2,6 +2,8 @@ REM Do a minimalistic build of LuaJIT using the MinGW compiler
 
 set PATH=C:\MinGW\bin;%PATH%
 
+set targetdir=%2
+
 REM retrieve and unpack source
 curl -fLsS -o %1.zip http://luajit.org/download/%1.zip
 unzip -q %1
@@ -12,7 +14,7 @@ sed -i "s/BUILDMODE=.*mixed/BUILDMODE=static/" %1\src\Makefile
 mingw32-make TARGET_SYS=Windows -C %1\src
 
 REM copy luajit.exe to project dir
-copy %1\src\luajit.exe %APPVEYOR_BUILD_FOLDER%
+copy %1\src\luajit.exe %APPVEYOR_BUILD_FOLDER%\%targetdir%
 
 REM clean up (remove source folders and archive)
 rm -rf %1/*

--- a/.appveyor/install-luajit.cmd
+++ b/.appveyor/install-luajit.cmd
@@ -14,7 +14,8 @@ sed -i "s/BUILDMODE=.*mixed/BUILDMODE=static/" %1\src\Makefile
 mingw32-make TARGET_SYS=Windows -C %1\src
 
 REM copy luajit.exe to project dir
-copy %1\src\luajit.exe %APPVEYOR_BUILD_FOLDER%\%targetdir%
+mkdir %APPVEYOR_BUILD_FOLDER%\%targetdir%
+copy %1\src\luajit.exe %APPVEYOR_BUILD_FOLDER%\%targetdir%\
 
 REM clean up (remove source folders and archive)
 rm -rf %1/*

--- a/TODO.txt
+++ b/TODO.txt
@@ -129,3 +129,5 @@ x sequence asserts
 x compatibilty tests with several version of lua
 x add assertNotEquals
 
+
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-
 TODO Future:
 ============
 - document prettystr

--- a/TODO.txt
+++ b/TODO.txt
@@ -25,6 +25,11 @@ TODO Future:
 - see StackTracePlus for printing more stack information: https://github.com/ignacio/StackTracePlus
 - how does busted deal with nested tables ? functions ?
 - look at serpent to see how to improve nested table printing
+- function should be printed as <function>
+- print table of test test_filterWithPattern and see how to improve readability
+- align the "OK" vertically for text output
+- better detection of screen size
+- shuffle should shuffle separately classes and then class methods
 
 Nice to have: 
 ============

--- a/TODO.txt
+++ b/TODO.txt
@@ -30,6 +30,8 @@ TODO Future:
 - align the "OK" vertically for text output
 - better detection of screen size
 - shuffle should shuffle separately classes and then class methods
+- catch the os.exit call with a handler or something, to avoid aborting the tests
+- add assertTableContains and assertTableNotContains to check the presence / absence of value in an array
 
 Nice to have: 
 ============
@@ -41,6 +43,8 @@ TODO for 3.3 release:
 - doc about scientific computing dedicated functions
 - doc about prettystr
 - doc about usage of prettystr & assertion library
+- fix include/exclude bug (see https://github.com/bluebird75/luaunit/pull/82 )
+
 
 
 Done since 3.2:

--- a/TODO.txt
+++ b/TODO.txt
@@ -128,3 +128,4 @@ x table assertions
 x sequence asserts
 x compatibilty tests with several version of lua
 x add assertNotEquals
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -133,3 +133,5 @@ x add assertNotEquals
 
 
 
+
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -128,5 +128,3 @@ x table assertions
 x sequence asserts
 x compatibilty tests with several version of lua
 x add assertNotEquals
-
-

--- a/TODO.txt
+++ b/TODO.txt
@@ -130,3 +130,4 @@ x compatibilty tests with several version of lua
 x add assertNotEquals
 
 
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -131,3 +131,5 @@ x add assertNotEquals
 
 
 
+
+

--- a/TODO.txt
+++ b/TODO.txt
@@ -130,4 +130,3 @@ x compatibilty tests with several version of lua
 x add assertNotEquals
 
 
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,12 @@ install:
 - cmd: .appveyor\install-lua.cmd
 
 cache:
-  - lua51 -> .appveyor\install-lua.cmd
+  - lua51       -> .appveyor\install-lua.cmd
+  - lua52       -> .appveyor\install-lua.cmd
+  - lua53       -> .appveyor\install-lua.cmd
+  - luajit20    -> .appveyor\install-lua.cmd
+  - luajit21    -> .appveyor\install-lua.cmd
+  - "C:\Program Files (x86)\Lua\" -> .appveyor\install-lua.cmd
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ cache:
   - lua53       -> .appveyor\install-lua.cmd
   - luajit20    -> .appveyor\install-lua.cmd
   - luajit21    -> .appveyor\install-lua.cmd
-  - 'C:\Program Files (x86)\Lua\' -> .appveyor\install-lua.cmd
+  - 'C:\Program Files (x86)\Lua' -> .appveyor\install-lua.cmd
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ cache:
   - lua53       -> .appveyor\install-lua.cmd
   - luajit20    -> .appveyor\install-lua.cmd
   - luajit21    -> .appveyor\install-lua.cmd
-  - 'C:\Program Files (x86)\Lua' -> .appveyor\install-lua.cmd
+  - 'C:\Program Files (x86)\Lua -> .appveyor\install-lua.cmd'
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ matrix:
 install:
 - cmd: .appveyor\install-lua.cmd
 
+cache:
+  - lua51 -> .appveyor\install-lua.cmd
+
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ shallow_clone: true
 # create a build matrix to use various Lua and LuaJIT versions
 environment:
   matrix:
-    - LUAENV: cinst
     - LUAENV: lua51
     - LUAENV: lua52
     - LUAENV: lua53
     - LUAENV: luajit20
     - LUAENV: luajit21
+    - LUAENV: cinst
 
 # cinst occasionally has problems, allow it to fail
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ cache:
   - lua53       -> .appveyor\install-lua.cmd
   - luajit20    -> .appveyor\install-lua.cmd
   - luajit21    -> .appveyor\install-lua.cmd
-  - "C:\Program Files (x86)\Lua\" -> .appveyor\install-lua.cmd
+  - 'C:\Program Files (x86)\Lua\' -> .appveyor\install-lua.cmd
 
 build: off
 


### PR DESCRIPTION
Reduce build time on AppVeyor by 60% by caching the lua for the different configurations. This also avoids build failing because of lua download failure (happening on a regular basis). Latest build on AppVeyor is now 1 min 21s