### PR TITLE
Changed assertErrorMsgEquals to check error raised as table

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1314,7 +1314,25 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error: "'..expectedMsg..'"', 2 )
     end
+    local differ = false
     if error_msg ~= expectedMsg then
+        local tr = type(error_msg)
+        local te = type(expectedMsg)
+        if te == 'table' then
+            if tr ~= 'table' then
+                differ = true
+            else
+                 local ok = pcall(M.assertItemsEquals, error_msg, expectedMsg)
+                 if not ok then
+                     differ = true
+                 end
+            end
+        else
+           differ = true
+        end
+    end
+
+    if differ then
         error_msg, expectedMsg = prettystrPairs(error_msg, expectedMsg)
         fail_fmt(2, 'Exact error message expected: %s\nError message received: %s\n',
                  expectedMsg, error_msg)

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1750,6 +1750,17 @@ TestLuaUnitAssertionsError = {}
         assertFailure( lu.assertErrorMsgEquals, 'toto', self.f, x )
         assertFailure( lu.assertErrorMsgEquals, 'is an err', self.f_with_error, x )
         lu.assertErrorMsgEquals( 'This is an error', self.f_with_error, x )
+
+        lu.assertErrorMsgEquals({1,2,3,4}, function() error({1,2,3,4}) end)
+
+        lu.assertErrorMsgEquals({
+            details = {1,2,3,4},
+            id = 10,
+        }, function() error({
+            details = {1,2,3,4},
+            id = 10,
+        }) end)
+
         assertFailure( lu.assertErrorMsgEquals, ' This is an error', self.f_with_error, x )
         assertFailure( lu.assertErrorMsgEquals, 'This .. an error', self.f_with_error, x )
     end
@@ -1987,6 +1998,9 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
         assertFailureEquals('Exact error message expected: "bla bla bla"\nError message received: "toto xxx"\n' , lu.assertErrorMsgEquals, 'bla bla bla', function( v ) error('toto xxx',2) end, 3 )
         assertFailureEquals('Error message does not contain: "bla bla bla"\nError message received: "toto xxx"\n' , lu.assertErrorMsgContains, 'bla bla bla', function( v ) error('toto xxx',2) end, 3 )
         assertFailureEquals('Error message does not match: "bla bla bla"\nError message received: "toto xxx"\n' , lu.assertErrorMsgMatches, 'bla bla bla', function( v ) error('toto xxx',2) end, 3 )
+
+        assertFailureEquals('Exact error message expected: {1, 2, 3, 4}\nError message received: {1, 2, 3}\n' , lu.assertErrorMsgEquals, {1,2,3,4}, function( v ) error(v) end, {1,2,3})
+        assertFailureEquals('Exact error message expected: {details="bla bla bla"}\nError message received: {details="ble ble ble"}\n' , lu.assertErrorMsgEquals, {details="bla bla bla"}, function( v ) error(v) end, {details="ble ble ble"})
 
     end 
 


### PR DESCRIPTION
Hi,
Here are changes to permit assertErrorMsgEquals to check if raised error matches a table.
Test results:
```
root@lab002143-basix-fe:luaunit# lua run_functional_tests.lua 
...................
Ran 19 tests in 0.110 seconds, 19 successes, 0 failures
OK
root@lab002143-basix-fe:luaunit# lua run_unit_tests.lua 
......................................................................................................................................................
Ran 150 tests in 0.021 seconds, 150 successes, 0 failures
OK
```