### PR TITLE
allow the assertError* functions to accept non-string errors assuming…

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1428,7 +1428,7 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error: "'..expectedMsg..'"', 2 )
     end
-    if type(error_msg) ~= "string" then
+    if type(expectedMsg) == "string" and type(error_msg) ~= "string" then
         error_msg = tostring(error_msg)
     end
     local differ = false

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1428,6 +1428,9 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error: "'..expectedMsg..'"', 2 )
     end
+    if type(error_msg) ~= "string" then
+        error_msg = tostring(error_msg)
+    end
     local differ = false
     if error_msg ~= expectedMsg then
         local tr = type(error_msg)
@@ -1460,6 +1463,9 @@ function M.assertErrorMsgContains( partialMsg, func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error containing: '..prettystr(partialMsg), 2 )
     end
+    if type(error_msg) ~= "string" then
+        error_msg = tostring(error_msg)
+    end
     if not string.find( error_msg, partialMsg, nil, true ) then
         error_msg, partialMsg = prettystrPairs(error_msg, partialMsg)
         fail_fmt(2, 'Error message does not contain: %s\nError message received: %s\n',
@@ -1473,6 +1479,9 @@ function M.assertErrorMsgMatches( expectedMsg, func, ... )
     local no_error, error_msg = pcall( func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error matching: "'..expectedMsg..'"', 2 )
+    end
+    if type(error_msg) ~= "string" then
+        error_msg = tostring(error_msg)
     end
     if not strMatch( error_msg, expectedMsg ) then
         expectedMsg, error_msg = prettystrPairs(expectedMsg, error_msg)

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1948,7 +1948,7 @@ TestLuaUnitAssertionsError = {}
             id = 10,
         }) end)
 
-        lu.assertErrorMsgEquals("500", function() error(500) end)
+        lu.assertErrorMsgEquals("500", function() error(500, 2) end)
 
         assertFailure( lu.assertErrorMsgEquals, ' This is an error', self.f_with_error, x )
         assertFailure( lu.assertErrorMsgEquals, 'This .. an error', self.f_with_error, x )
@@ -1960,7 +1960,7 @@ TestLuaUnitAssertionsError = {}
         assertFailure( lu.assertErrorMsgMatches, 'is an err', self.f_with_error, x )
         lu.assertErrorMsgMatches( 'This is an error', self.f_with_error, x )
         lu.assertErrorMsgMatches( 'This is .. error', self.f_with_error, x )
-        lu.assertErrorMsgMatches("^500$", function() error(500) end)
+        lu.assertErrorMsgMatches(".*500$", function() error(500, 2) end)
         assertFailure( lu.assertErrorMsgMatches, ' This is an error', self.f_with_error, x )
     end
 

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1929,6 +1929,7 @@ TestLuaUnitAssertionsError = {}
         lu.assertErrorMsgContains( 'This is an error', self.f_with_error, x )
         assertFailure( lu.assertErrorMsgContains, ' This is an error', self.f_with_error, x )
         assertFailure( lu.assertErrorMsgContains, 'This .. an error', self.f_with_error, x )
+        lu.assertErrorMsgContains("50", function() error(500) end)
     end
 
     function TestLuaUnitAssertionsError:test_assertErrorMsgEquals()
@@ -1947,6 +1948,8 @@ TestLuaUnitAssertionsError = {}
             id = 10,
         }) end)
 
+        lu.assertErrorMsgEquals("500", function() error(500) end)
+
         assertFailure( lu.assertErrorMsgEquals, ' This is an error', self.f_with_error, x )
         assertFailure( lu.assertErrorMsgEquals, 'This .. an error', self.f_with_error, x )
     end
@@ -1957,6 +1960,7 @@ TestLuaUnitAssertionsError = {}
         assertFailure( lu.assertErrorMsgMatches, 'is an err', self.f_with_error, x )
         lu.assertErrorMsgMatches( 'This is an error', self.f_with_error, x )
         lu.assertErrorMsgMatches( 'This is .. error', self.f_with_error, x )
+        lu.assertErrorMsgMatches("^500$", function() error(500) end)
         assertFailure( lu.assertErrorMsgMatches, ' This is an error', self.f_with_error, x )
     end
 


### PR DESCRIPTION
… that tostring can convert them (assuming that, for example, the __tostring function is set in an error table metatable)


This is related to issue #104.