### PR TITLE
Add assertErrorMsgContentEquals

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1451,6 +1451,21 @@ function M.assertErrorMsgMatches( expectedMsg, func, ... )
     end
 end
 
+function M.assertErrorMsgContentEquals(expected_message, func, ...)
+    local success, error_message = pcall(func, ...)
+    if success then
+        failure( 'No error generated when calling function but expected error containing: '..prettystr(partialMsg), nil, 2 )
+    end
+    if type(error_message) ~= "string" then
+        error_message = tostring(error_message)
+    end
+    if error_message:gsub("^.+:%d+: ", "") ~= expected_message then
+        expected_message, error_message = prettystrPairs(expected_message, error_message)
+        fail_fmt(2, nil, 'Error message expected: %s\nError message received: %s\n',
+                 expected_message, error_message)
+    end
+end
+
 ------------------------------------------------------------------
 --              Type assertions
 ------------------------------------------------------------------
@@ -1723,6 +1738,7 @@ local list_of_funcs = {
     { 'assertErrorMsgEquals'    , 'assert_error_msg_equals' },
     { 'assertErrorMsgContains'  , 'assert_error_msg_contains' },
     { 'assertErrorMsgMatches'   , 'assert_error_msg_matches' },
+    { 'assertErrorMsgContentEquals' , 'assert_error_msg_content_equals' },
     { 'assertIs'                , 'assert_is' },
     { 'assertNotIs'             , 'assert_not_is' },
     { 'wrapFunctions'           , 'WrapFunctions' },

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -2774,6 +2774,13 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
             lu.assertErrorMsgMatches, 'bla bla bla', function( v ) error('toto xxx',2) end, 3 )
     end 
 
+    function TestLuaUnitErrorMsg:test_assertErrorMsgContentEquals()
+       local f = function() error("This is error message") end
+       lu.assertErrorMsgContentEquals("This is error message", f)
+       local f1 = function(v1, v2) error("This is error message") end
+       lu.assertErrorMsgContentEquals("This is error message", f, 1, 2)
+    end
+
     function TestLuaUnitErrorMsg:test_printTableWithRef()
         lu.PRINT_TABLE_REF_IN_ERROR_MSG = true
         assertFailureMatches( 'Received the not expected value: <table: 0?x?[%x]+> {1, 2}', lu.assertNotEquals, {1,2}, {1,2} )


### PR DESCRIPTION
Both assertErrorMsgContains and assertErrorMsgMatches matches
the expected error message if the actual error message includes extra
things. The new function assertErrorMsgContentEquals matches the
expected error message only. It will fail assertion if actual error
message includes extra things.