### PR TITLE
Reorganize adding assertErrorMsgContentEquals

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1392,7 +1392,7 @@ end
 local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
     local no_error, error_msg = pcall( func, ... )
     if no_error then
-        failure( 'No error generated when calling function but expected error: '..M.prettystr(expectedMsg), nil, 2 )
+        failure( 'No error generated when calling function but expected error: '..M.prettystr(expectedMsg), nil, 3 )
     end
     if type(expectedMsg) == "string" and type(error_msg) ~= "string" then
         -- table are converted to string automatically
@@ -1418,7 +1418,7 @@ local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
 
     if differ then
         error_msg, expectedMsg = prettystrPairs(error_msg, expectedMsg)
-        fail_fmt(2, nil, 'Error message expected: %s\nError message received: %s\n',
+        fail_fmt(3, nil, 'Error message expected: %s\nError message received: %s\n',
                  expectedMsg, error_msg)
     end
 end

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1399,6 +1399,11 @@ local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
         error_msg = tostring(error_msg)
     end
     local differ = false
+    if stripFileAndLine then
+        if error_msg:gsub("^.+:%d+: ", "") ~= expectedMsg then
+            differ = true
+        end
+    else
     if error_msg ~= expectedMsg then
         local tr = type(error_msg)
         local te = type(expectedMsg)
@@ -1415,6 +1420,7 @@ local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
            differ = true
         end
     end
+    end
 
     if differ then
         error_msg, expectedMsg = prettystrPairs(error_msg, expectedMsg)
@@ -1427,6 +1433,10 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
     -- assert that calling f with the arguments will raise an error
     -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
     _assertErrorMsgEquals(false, expectedMsg, func, ...)
+end
+
+function M.assertErrorMsgContentEquals(expectedMsg, func, ...)
+     _assertErrorMsgEquals(true, expectedMsg, func, ...)
 end
 
 function M.assertErrorMsgContains( partialMsg, func, ... )
@@ -1735,6 +1745,7 @@ local list_of_funcs = {
     { 'assertErrorMsgEquals'    , 'assert_error_msg_equals' },
     { 'assertErrorMsgContains'  , 'assert_error_msg_contains' },
     { 'assertErrorMsgMatches'   , 'assert_error_msg_matches' },
+    { 'assertErrorMsgContentEquals', 'assert_error_msg_content_equals' },
     { 'assertIs'                , 'assert_is' },
     { 'assertNotIs'             , 'assert_not_is' },
     { 'wrapFunctions'           , 'WrapFunctions' },

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1404,22 +1404,22 @@ local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
             differ = true
         end
     else
-    if error_msg ~= expectedMsg then
-        local tr = type(error_msg)
-        local te = type(expectedMsg)
-        if te == 'table' then
-            if tr ~= 'table' then
-                differ = true
+        if error_msg ~= expectedMsg then
+            local tr = type(error_msg)
+            local te = type(expectedMsg)
+            if te == 'table' then
+                if tr ~= 'table' then
+                    differ = true
+                else
+                     local ok = pcall(M.assertItemsEquals, error_msg, expectedMsg)
+                     if not ok then
+                         differ = true
+                     end
+                end
             else
-                 local ok = pcall(M.assertItemsEquals, error_msg, expectedMsg)
-                 if not ok then
-                     differ = true
-                 end
+               differ = true
             end
-        else
-           differ = true
         end
-    end
     end
 
     if differ then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -1389,9 +1389,7 @@ function M.assertStrMatches( str, pattern, start, final, extra_msg_or_nil )
     end
 end
 
-function M.assertErrorMsgEquals( expectedMsg, func, ... )
-    -- assert that calling f with the arguments will raise an error
-    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+local function _assertErrorMsgEquals( stripFileAndLine, expectedMsg, func, ... )
     local no_error, error_msg = pcall( func, ... )
     if no_error then
         failure( 'No error generated when calling function but expected error: '..M.prettystr(expectedMsg), nil, 2 )
@@ -1423,6 +1421,12 @@ function M.assertErrorMsgEquals( expectedMsg, func, ... )
         fail_fmt(2, nil, 'Error message expected: %s\nError message received: %s\n',
                  expectedMsg, error_msg)
     end
+end
+
+function M.assertErrorMsgEquals( expectedMsg, func, ... )
+    -- assert that calling f with the arguments will raise an error
+    -- example: assertError( f, 1, 2 ) => f(1,2) should generate an error
+    _assertErrorMsgEquals(false, expectedMsg, func, ...)
 end
 
 function M.assertErrorMsgContains( partialMsg, func, ... )

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -2785,6 +2785,13 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
             lu.assertErrorMsgMatches, 'bla bla bla', function( v ) error('toto xxx',2) end, 3 )
     end 
 
+    function TestLuaUnitErrorMsg:test_assertErrorMsgContentEquals()
+        local f = function() error("This is error message") end
+        lu.assertErrorMsgContentEquals("This is error message", f)
+        local f1 = function(v1, v2) error("This is error message") end
+        lu.assertErrorMsgContentEquals("This is error message", f, 1, 2)
+    end
+
     function TestLuaUnitErrorMsg:test_printTableWithRef()
         lu.PRINT_TABLE_REF_IN_ERROR_MSG = true
         assertFailureMatches( 'Received the not expected value: <table: 0?x?[%x]+> {1, 2}', lu.assertNotEquals, {1,2}, {1,2} )


### PR DESCRIPTION
Both assertErrorMsgContains and assertErrorMsgMatches matches
the expected error message if the actual error message includes extra
things. The new function assertErrorMsgContentEquals matches the
expected error message only. It will fail assertion if actual error
message includes extra things.

See also #109