### PR TITLE
Flush output in the default verbosity

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -2190,6 +2190,7 @@ TextOutput.__class__ = 'TextOutput'
                 io.stdout:write("Ok\n")
             else
                 io.stdout:write(".")
+                io.stdout:flush()
             end
         else
             if self.verbosity > M.VERBOSITY_DEFAULT then
@@ -2204,6 +2205,7 @@ TextOutput.__class__ = 'TextOutput'
             else
                 -- write only the first character of status
                 io.stdout:write(string.sub(node.status, 1, 1))
+                io.stdout:flush()
             end
         end
     end


### PR DESCRIPTION
In the default verbosity, LuaUnit outputs one character such as "."
and "E". We can't know the one character progress until all tests are
finished or the stdout internal buffer is fulled because the one
characters are buffered in the stdout internal buffer.

We can the one character progress immediately by flushing the stdout
internal buffer.