### PR TITLE
Fix `_table_raw_tostring()` error and show brief string for values in fail messages of `assertIs()`/`assertNotIs()`.

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -876,6 +876,18 @@ local function _table_raw_tostring( t )
 end
 M.private._table_raw_tostring = _table_raw_tostring
 
+local function briefstr(value)
+    local type_v = type(value)
+    if "string" == type_v then
+        return prettystr(value)
+    elseif "table" == type_v then
+        return _table_raw_tostring(value)
+    else
+        return tostring(value)
+    end
+end
+M.private.briefstr = briefstr
+
 local TABLE_TOSTRING_SEP = ", "
 local TABLE_TOSTRING_SEP_LEN = string.len(TABLE_TOSTRING_SEP)
 
@@ -1608,7 +1620,7 @@ function M.assertIs(actual, expected, extra_msg_or_nil)
         if not M.ORDER_ACTUAL_EXPECTED then
             actual, expected = expected, actual
         end
-        expected, actual = prettystrPairs(expected, actual, '\n', '')
+        expected, actual = briefstr(expected), briefstr(actual)
         fail_fmt(2, extra_msg_or_nil, 'expected and actual object should not be different\nExpected: %s\nReceived: %s',
                  expected, actual)
     end
@@ -1620,7 +1632,7 @@ function M.assertNotIs(actual, expected, extra_msg_or_nil)
             expected = actual
         end
         fail_fmt(2, extra_msg_or_nil, 'expected and actual object should be different: %s',
-                 prettystrPairs(expected))
+                 briefstr(expected))
     end
 end
 

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -866,9 +866,12 @@ local function _table_raw_tostring( t )
     -- return the default tostring() for tables, with the table ID, even if the table has a metatable
     -- with the __tostring converter
     local mt = getmetatable( t )
-    if mt then setmetatable( t, nil ) end
+    if not mt or type(mt) ~= "table" or mt.__metatable ~= nil then
+        return tostring(t)
+    end
+    setmetatable( t, nil )
     local ref = tostring(t)
-    if mt then setmetatable( t, mt ) end
+    setmetatable( t, mt )
     return ref
 end
 M.private._table_raw_tostring = _table_raw_tostring

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -2716,9 +2716,7 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
 
     function TestLuaUnitErrorMsg:test_assertIs()
         assertFailureEquals( 'expected and actual object should not be different\nExpected: 1\nReceived: 2', lu.assertIs, 2, 1 )
-        assertFailureEquals( 'expected and actual object should not be different\n'..
-                                'Expected: {1, 2, 3, 4, 5, 6, 7, 8}\n'..
-                                'Received: {1, 2, 3, 4, 5, 6, 7, 8}', 
+        assertFailureMatches( 'expected and actual object should not be different\nExpected: table: 0?x?[%x]+\nReceived: table: 0?x?[%x]+',
             lu.assertIs, {1,2,3,4,5,6,7,8}, {1,2,3,4,5,6,7,8} )
         lu.ORDER_ACTUAL_EXPECTED = false
         assertFailureEquals( 'expected and actual object should not be different\nExpected: 2\nReceived: 1', lu.assertIs, 2, 1 )
@@ -2727,10 +2725,10 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
 
     function TestLuaUnitErrorMsg:test_assertNotIs()
         local v = {1,2}
-        assertFailureMatches( 'expected and actual object should be different: {1, 2}', lu.assertNotIs, v, v )
+        assertFailureMatches( 'expected and actual object should be different: table: 0?x?[%x]+', lu.assertNotIs, v, v )
         lu.ORDER_ACTUAL_EXPECTED = false -- order shouldn't matter here, but let's cover it
-        assertFailureMatches( 'expected and actual object should be different: {1, 2}', lu.assertNotIs, v, v )
-        assertFailureMatches( 'toto\nexpected and actual object should be different: {1, 2}', lu.assertNotIs, v, v, 'toto' )
+        assertFailureMatches( 'expected and actual object should be different: table: 0?x?[%x]+', lu.assertNotIs, v, v )
+        assertFailureMatches( 'toto\nexpected and actual object should be different: table: 0?x?[%x]+', lu.assertNotIs, v, v, 'toto' )
     end 
 
     function TestLuaUnitErrorMsg:test_assertItemsEquals()
@@ -2787,7 +2785,7 @@ TestLuaUnitErrorMsg = { __class__ = 'TestLuaUnitErrorMsg' }
         assertFailureMatches( 'Received the not expected value: <table: 0?x?[%x]+> {1, 2, 3, 4}', lu.assertNotEquals, {1,2,3,4}, {1,2,3,4} )
         assertFailureMatches( 'expected: false, actual: <table: 0?x?[%x]+> {}', lu.assertFalse, {})
         local v = {1,2}
-        assertFailureMatches( 'expected and actual object should be different: <table: 0?x?[%x]+> {1, 2}', lu.assertNotIs, v, v )
+        assertFailureMatches( 'expected and actual object should be different: table: 0?x?[%x]+', lu.assertNotIs, v, v )
         assertFailureMatches('Content of the tables are not identical:\nExpected: <table: 0?x?[%x]+> {one=2, two=3}\nActual: <table: 0?x?[%x]+> {1, 2}' , lu.assertItemsEquals, {1,2}, {one=2, two=3} )
         assertFailureMatches( 'expected: <table: 0?x?[%x]+> {1, 2}\nactual: <table: 0?x?[%x]+> {2, 1}', lu.assertEquals, {2,1}, {1,2} )
         -- trigger multiline prettystr


### PR DESCRIPTION
Related issue: #118