### PR TITLE
Add GLOBAL_TESTS option

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -65,7 +65,7 @@ Version 3.4:
 - catch the os.exit call with a handler or something, to avoid aborting the tests
 - move all file:line description to stack trace
 - better deal with one line formatting
-
+- GLOBAL_TESTS option to define tests outside of global scope
 
 Done since 3.2:
 ===============

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -3628,11 +3628,11 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
         runner.run('--output', 'nil', 'MyTestOk.testOk2')
 
         -- check error handling
-        lu.assertErrorMsgContains('No such name in global space',
+        lu.assertErrorMsgContains('No such name in tests container',
                                   runner.runSuite, runner, 'foobar')
         lu.assertErrorMsgContains('Name must match a function or a table',
                                   runner.runSuite, runner, '_VERSION')
-        lu.assertErrorMsgContains('No such name in global space',
+        lu.assertErrorMsgContains('No such name in tests container',
                                   runner.runSuite, runner, 'foo.bar')
         lu.assertErrorMsgContains('must be a function, not',
                                   runner.runSuite, runner, '_G._VERSION')


### PR DESCRIPTION
To be able to define test outside of global namespace

Hi!

With this patch it's possible to define tests and groups outside of global namespace.

```lua
local lu = require('luaunit')
local t = lu.group('SomeFeauture')

t.setup = function()....
t.testSmth = function() ...
```

It's a good practice to not introduce unnecessary global variables and luacheck warns on this by default.