### PR TITLE
Adapt randomseed to Lua 5.4

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -213,11 +213,7 @@ end
 M.private.sortedPairs = sortedPairs
 
 -- seed the random with a strongly varying seed
-if _VERSION <= "Lua 5.3" then
-    math.randomseed(os.clock()*1E11)
-else
-    math.randomseed()
-end
+math.randomseed(math.floor(os.clock()*1E11))
 
 local function randomizeTable( t )
     -- randomize the item orders of the table t

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -213,7 +213,11 @@ end
 M.private.sortedPairs = sortedPairs
 
 -- seed the random with a strongly varying seed
-math.randomseed(os.clock()*1E11)
+if _VERSION <= "Lua 5.3" then
+    math.randomseed(os.clock()*1E11)
+else
+    math.randomseed()
+end
 
 local function randomizeTable( t )
     -- randomize the item orders of the table t


### PR DESCRIPTION
The `math.randomseed` method has been updated in _Lua_ 5.4, see [Lua reference](https://www.lua.org/manual/5.4/manual.html#pdf-math.randomseed).
The current _luaunit_ usage fails occasionally with the error "_bad argument # 1 to 'randomseed' (number has no integer representation)_".
This pull request will call the method without arguments when using _Lua_ 5.4.