### PR TITLE
travis: fix [ usage

### DIFF
--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -107,7 +107,7 @@ else # -e $LUA_HOME_DIR
 
         # adjust numerical precision if requested with LUANUMBER=float
         if [ "$LUANUMBER" == "float" ]; then
-            if [ "$LUA" == "lua5.3" || "$LUA" == "lua5.4" ]; then
+            if [ "$LUA" == "lua5.3" -o "$LUA" == "lua5.4" ]; then
                 # for Lua 5.3 we can simply adjust the default float type
                 perl -i -pe "s/#define LUA_FLOAT_TYPE\tLUA_FLOAT_DOUBLE/#define LUA_FLOAT_TYPE\tLUA_FLOAT_FLOAT/" src/luaconf.h
             else


### PR DESCRIPTION
The || operator is actually a shell construct, not recognized by test/[. We
could change this to [ expr ] || [ expr2 ], but it's cheaper to just use
the POSIX-specified -o instead.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>

--

Noticed while looking at the build log, in before_install.1 of the LUANUMBER=float jobs: 

+'[' lua5.2 == lua5.3
.travis/setup_lua.sh: line 110: [: missing `]'
+lua5.2 == lua5.4 ']'
.travis/setup_lua.sh: line 110: lua5.2: command not found
