### PR TITLE
Allow the output format to be specified by the environment

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -3239,6 +3239,8 @@ end
         self.patternIncludeFilter = options.pattern
         self.shuffle              = options.shuffle
 
+        options.output     = options.output or os.getenv('LUAUNIT_DEFAULT_OUTPUT')
+
         if options.output then
             if options.output:lower() == 'junit' and options.fname == nil then
                 print('With junit output, a filename must be supplied with -n or --name')

--- a/run_functional_tests.lua
+++ b/run_functional_tests.lua
@@ -182,7 +182,11 @@ local function check_tap_output( fileToRun, options, output, refOutput, refExitC
     if not envOptions:match("LUAUNIT_DEFAULT_OUTPUT[^%w]") then
         outputArg = '--output TAP'
     end
-    osExpectedCodeExec(refExitCode, '/usr/bin/env -S %s %s %s %s %s > %s',
+    if envOptions ~= '' then
+        envOptions = '/usr/bin/env -S ' .. envOptions
+    end
+
+    osExpectedCodeExec(refExitCode, '%s %s %s %s %s > %s',
                        envOptions, LUA, fileToRun, outputArg, options, output)
 
     adjustFile( output, refOutput, '# Started on (.*)')
@@ -319,11 +323,16 @@ function testTapDefault()
         check_tap_output('test/test_with_err_fail_pass.lua', '-p Succ -p Fail',
             'test/errFailPassTapDefault-failures.txt', 
             'test/ref/errFailPassTapDefault-failures.txt', 5 ) )
-    lu.assertEquals( 0,
-        check_tap_output('test/test_with_err_fail_pass.lua', '-p Succ -p Fail',
-            'test/errFailPassTapDefault-failures.txt', 
-            'test/ref/errFailPassTapDefault-failures.txt', 5,
-            'LUAUNIT_DEFAULT_OUTPUT=TAP' ) )
+    if IS_UNIX then
+        -- It is non-trivial to set the environment for new command execution
+        -- on Windows, so we'll only attempt it on UNIX.  These systems should
+        -- all have /usr/bin/env, and -S is pretty standard these days.
+        lu.assertEquals( 0,
+            check_tap_output('test/test_with_err_fail_pass.lua', '-p Succ -p Fail',
+                'test/errFailPassTapDefault-failures.txt', 
+                'test/ref/errFailPassTapDefault-failures.txt', 5,
+                'LUAUNIT_DEFAULT_OUTPUT=TAP' ) )
+    end
 end
 
 function testTapVerbose()


### PR DESCRIPTION
Described in a little more in-depth in the commit messages, but this small PR would be quite appreciated -- this will check for LUAUNIT_DEFAULT_OUTPUT in the environment and use that as if it were supplied as the --output option in the absence of an overriding --output option from the arguments. This opens us up to using a shebang line to fully specify how the test is generally desired to be read:

```
#!/usr/bin/env -S LUAUNIT_DEFAULT_OUTPUT=TAP /usr/local/bin/lua53
```

Specifically, I'd like to import luaunit into FreeBSD's base system for unit testing of the lua bindings we're writing for various base libs, and our infrastructure can/will insert effectively the above shebang (except using our base lua interpreter) so that the test driver (Kyua) can just execute this test like it does any other test and examine the output without having to understand that it's a lua script or anything else.

A functional smoke test has been added to insert LUAUNIT_DEFAULT_OUTPUT into the environment for one of the TAP tests that's already passed to try and make it clear if any failure is due to a regression in the TAP output vs. the new environment variable. TAP was randomly chosen for this example because it was the first non-default format test that I came across.

