### PR TITLE
Lua 5.4 compatibility

### DIFF
--- a/luaunit-3.3-1.rockspec
+++ b/luaunit-3.3-1.rockspec
@@ -34,7 +34,7 @@ description =
 
 dependencies =
 {
-	"lua >= 5.1", "lua < 5.4"
+	"lua >= 5.1", "lua < 5.5"
 }
 
 build =


### PR DESCRIPTION
Hello,

As far as I can tell from testing it on one of my projects, luaunit works fine on Lua 5.4. This change would make it possible to install with that version (if merged, this change should be published on luarocks, of course). Of course, LuaUnit's tests themselves pass fine with Lua 5.4.1 that I have on my system (Linux Fedora).

Thanks,
Martin