### PR TITLE
Add method and test prefix options.

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -76,25 +76,27 @@ M.SKIP_PREFIX    = 'LuaUnit test SKIP:    ' -- prefix string for skipped tests
 
 M.USAGE=[[Usage: lua <your_test_suite.lua> [options] [testname1 [testname2] ... ]
 Options:
-  -h, --help:             Print this help
-  --version:              Print version information
-  -v, --verbose:          Increase verbosity
-  -q, --quiet:            Set verbosity to minimum
-  -e, --error:            Stop on first error
-  -f, --failure:          Stop on first failure or error
-  -s, --shuffle:          Shuffle tests before running them
-  -o, --output OUTPUT:    Set output type to OUTPUT
-                          Possible values: text, tap, junit, nil
-  -n, --name NAME:        For junit only, mandatory name of xml file
-  -r, --repeat NUM:       Execute all tests NUM times, e.g. to trig the JIT
-  -p, --pattern PATTERN:  Execute all test names matching the Lua PATTERN
-                          May be repeated to include several patterns
-                          Make sure you escape magic chars like +? with %
-  -x, --exclude PATTERN:  Exclude all test names matching the Lua PATTERN
-                          May be repeated to exclude several patterns
-                          Make sure you escape magic chars like +? with %
-  testname1, testname2, ... : tests to run in the form of testFunction,
-                              TestClass or TestClass.testMethod
+  -h, --help:                  Print this help
+  --version:                   Print version information
+  -v, --verbose:               Increase verbosity
+  -q, --quiet:                 Set verbosity to minimum
+  -e, --error:                 Stop on first error
+  -f, --failure:               Stop on first failure or error
+  -s, --shuffle:               Shuffle tests before running them
+  -o, --output OUTPUT:         Set output type to OUTPUT
+                               Possible values: text, tap, junit, nil
+  -n, --name NAME:             For junit only, mandatory name of xml file
+  -r, --repeat NUM:            Execute all tests NUM times, e.g. to trig the JIT
+  -p, --pattern PATTERN:       Execute all test names matching the Lua PATTERN
+                               May be repeated to include several patterns
+                               Make sure you escape magic chars like +? with %
+  -x, --exclude PATTERN:       Exclude all test names matching the Lua PATTERN
+                               May be repeated to exclude several patterns
+                               Make sure you escape magic chars like +? with %
+  -m, --method-prefix PREFIX:  Execute methods that start with the PREFIX (default: test)
+  -t, --test-prefix PREFIX:    Execute tests that start with the PREFIX (default: test)
+  testname1, testname2, ... :  tests to run in the form of testFunction,
+                               TestClass or TestClass.testMethod
 
 You may also control LuaUnit options with the following environment variables:
 * LUAUNIT_OUTPUT: same as --output
@@ -2531,25 +2533,27 @@ end
         return nil, someName
     end
 
-    function M.LuaUnit.isMethodTestName( s )
+    function M.LuaUnit:isMethodTestName( s )
         -- return true is the name matches the name of a test method
         -- default rule is that is starts with 'Test' or with 'test'
-        return string.sub(s, 1, 4):lower() == 'test'
+        local prefix = self.methodPrefix or 'test'
+        return string.sub(s, 1, #prefix):lower() == prefix
     end
 
-    function M.LuaUnit.isTestName( s )
+    function M.LuaUnit:isTestName( s )
         -- return true is the name matches the name of a test
         -- default rule is that is starts with 'Test' or with 'test'
-        return string.sub(s, 1, 4):lower() == 'test'
+        local prefix = self.testPrefix or 'test'
+        return string.sub(s, 1, #prefix):lower() == prefix
     end
 
-    function M.LuaUnit.collectTests()
+    function M.LuaUnit:collectTests()
         -- return a list of all test names in the global namespace
         -- that match LuaUnit.isTestName
 
         local testNames = {}
         for k, _ in pairs(_G) do
-            if type(k) == "string" and M.LuaUnit.isTestName( k ) then
+            if type(k) == "string" and self:isTestName( k ) then
                 table.insert( testNames , k )
             end
         end
@@ -2566,6 +2570,8 @@ end
         -- --output, -o, + name: select output type
         -- --pattern, -p, + pattern: run test matching pattern, may be repeated
         -- --exclude, -x, + pattern: run test not matching pattern, may be repeated
+        -- --method-prefix, -m, + prefix: prefix of test methods (default: test)
+        -- --test-prefix, -t, + prefix: prefix of tests (default: test)
         -- --shuffle, -s, : shuffle tests before reunning them
         -- --name, -n, + fname: name of output file for junit, default to stdout
         -- --repeat, -r, + num: number of times to execute each test
@@ -2585,6 +2591,8 @@ end
         local SET_EXCLUDE = 3
         local SET_FNAME = 4
         local SET_REPEAT = 5
+        local SET_METHOD_PREFIX = 6
+        local SET_TEST_PREFIX = 7
 
         if cmdLine == nil then
             return result
@@ -2627,6 +2635,12 @@ end
             elseif option == '--exclude' or option == '-x' then
                 state = SET_EXCLUDE
                 return state
+            elseif option == '--method-prefix' or option == '-m' then
+                state = SET_METHOD_PREFIX
+                return state
+            elseif option == '--test-prefix' or option == '-t' then
+                state = SET_TEST_PREFIX
+                return state
             end
             error('Unknown option: '..option,3)
         end
@@ -2656,6 +2670,12 @@ end
                 else
                     result['pattern'] = { notArg }
                 end
+                return
+            elseif state == SET_METHOD_PREFIX then
+                result['methodPrefix'] = cmdArg
+                return
+            elseif state == SET_TEST_PREFIX then
+                result['testPrefix'] = cmdArg
                 return
             end
             error('Unknown parse state: '.. state)
@@ -3115,21 +3135,21 @@ end
         self:endTest()
     end
 
-    function M.LuaUnit.expandOneClass( result, className, classInstance )
+    function M.LuaUnit:expandOneClass( result, className, classInstance )
         --[[
         Input: a list of { name, instance }, a class name, a class instance
         Ouptut: modify result to add all test method instance in the form:
         { className.methodName, classInstance }
         ]]
         for methodName, methodInstance in sortedPairs(classInstance) do
-            if M.LuaUnit.asFunction(methodInstance) and M.LuaUnit.isMethodTestName( methodName ) then
+            if M.LuaUnit.asFunction(methodInstance) and self:isMethodTestName( methodName ) then
                 table.insert( result, { className..'.'..methodName, classInstance } )
             end
         end
     end
-
-    function M.LuaUnit.expandClasses( listOfNameAndInst )
+    function M.LuaUnit:expandClasses( listOfNameAndInst )
         --[[
+
         -- expand all classes (provided as {className, classInstance}) to a list of {className.methodName, classInstance}
         -- functions and methods remain untouched
 
@@ -3158,7 +3178,7 @@ end
                     end
                     table.insert( result, { name, instance } )
                 else
-                    M.LuaUnit.expandOneClass( result, name, instance )
+                    M.LuaUnit:expandOneClass( result, name, instance )
                 end
             end
         end
@@ -3228,7 +3248,7 @@ end
         This function is internal to LuaUnit. The official API to perform this action is runSuiteByInstances()
         ]]
 
-        local expandedList = self.expandClasses( listOfNameAndInst )
+        local expandedList = self:expandClasses( listOfNameAndInst )
         if self.shuffle then
             randomizeTable( expandedList )
         end
@@ -3393,6 +3413,8 @@ end
         self.exeRepeat            = options.exeRepeat
         self.patternIncludeFilter = options.pattern
         self.shuffle              = options.shuffle
+        self.methodPrefix         = options.methodPrefix
+        self.testPrefix           = options.testPrefix
 
         options.output     = options.output or os.getenv('LUAUNIT_OUTPUT')
         options.fname      = options.fname  or os.getenv('LUAUNIT_JUNIT_FNAME')
@@ -3411,7 +3433,7 @@ end
     function M.LuaUnit:runSuite( ... )
         testNames = self:initFromArguments(...)
         self:registerSuite()
-        self:internalRunSuiteByNames( testNames or M.LuaUnit.collectTests() )
+        self:internalRunSuiteByNames( testNames or self:collectTests() )
         self:unregisterSuite()
         return self.result.notSuccessCount
     end

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -681,11 +681,11 @@ bar"=1}]] )
     end
 
     function TestLuaUnitUtilities:test_isTestName()
-        lu.assertEquals( lu.LuaUnit.isTestName( 'testToto' ), true )
-        lu.assertEquals( lu.LuaUnit.isTestName( 'TestToto' ), true )
-        lu.assertEquals( lu.LuaUnit.isTestName( 'TESTToto' ), true )
-        lu.assertEquals( lu.LuaUnit.isTestName( 'xTESTToto' ), false )
-        lu.assertEquals( lu.LuaUnit.isTestName( '' ), false )
+        lu.assertEquals( lu.LuaUnit:isTestName( 'testToto' ), true )
+        lu.assertEquals( lu.LuaUnit:isTestName( 'TestToto' ), true )
+        lu.assertEquals( lu.LuaUnit:isTestName( 'TESTToto' ), true )
+        lu.assertEquals( lu.LuaUnit:isTestName( 'xTESTToto' ), false )
+        lu.assertEquals( lu.LuaUnit:isTestName( '' ), false )
     end
 
     function TestLuaUnitUtilities:test_parseCmdLine()
@@ -737,6 +737,18 @@ bar"=1}]] )
             { pattern={'toto', 'tutu'}, verbosity=lu.VERBOSITY_VERBOSE, output='tintin', testNames={'titi', 'tata', 'prout'}, fname='toto.xml' } )
 
         lu.assertErrorMsgContains( 'option: -$', lu.LuaUnit.parseCmdLine, { '-$', } )
+
+        -- method-prefix
+        lu.assertEquals( lu.LuaUnit.parseCmdLine( { '--method-prefix', 'should' } ), { methodPrefix='should' } )
+        lu.assertEquals( lu.LuaUnit.parseCmdLine( { '-m', 'should' } ), { methodPrefix='should' } )
+        lu.assertErrorMsgContains( 'Missing argument after -m', lu.LuaUnit.parseCmdLine, { '-m', } )
+
+        -- test-prefix
+        lu.assertEquals( lu.LuaUnit.parseCmdLine( { '--test-prefix', 'should' } ), { testPrefix='should' } )
+        lu.assertEquals( lu.LuaUnit.parseCmdLine( { '-t', 'should' } ), { testPrefix='should' } )
+        lu.assertErrorMsgContains( 'Missing argument after -t', lu.LuaUnit.parseCmdLine, { '-t', } )
+
+        lu.assertErrorMsgContains( 'Missing argument after -x', lu.LuaUnit.parseCmdLine, { '-x', } )
     end
 
     function TestLuaUnitUtilities:test_patternFilter()
@@ -846,12 +858,12 @@ bar"=1}]] )
 
     function TestLuaUnitUtilities:test_expandOneClass()
         local result = {}
-        lu.LuaUnit.expandOneClass( result, 'titi', {} )
+        lu.LuaUnit:expandOneClass( result, 'titi', {} )
         lu.assertEquals( result, {} )
 
         result = {}
-        lu.LuaUnit.expandOneClass( result, 'MyTestToto1', MyTestToto1 )
-        lu.assertEquals( result, { 
+        lu.LuaUnit:expandOneClass( result, 'MyTestToto1', MyTestToto1 )
+        lu.assertEquals( result, {
             {'MyTestToto1.test1', MyTestToto1 },
             {'MyTestToto1.test2', MyTestToto1 },
             {'MyTestToto1.test3', MyTestToto1 },
@@ -862,16 +874,16 @@ bar"=1}]] )
 
     function TestLuaUnitUtilities:test_expandClasses()
         local result
-        result = lu.LuaUnit.expandClasses( {} )
+        result = lu.LuaUnit:expandClasses( {} )
         lu.assertEquals( result, {} )
 
-        result = lu.LuaUnit.expandClasses( { { 'MyTestFunction', MyTestFunction } } )
+        result = lu.LuaUnit:expandClasses( { { 'MyTestFunction', MyTestFunction } } )
         lu.assertEquals( result, { { 'MyTestFunction', MyTestFunction } } )
 
-        result = lu.LuaUnit.expandClasses( { { 'MyTestToto1.test1', MyTestToto1 } } )
+        result = lu.LuaUnit:expandClasses( { { 'MyTestToto1.test1', MyTestToto1 } } )
         lu.assertEquals( result, { { 'MyTestToto1.test1', MyTestToto1 } } )
 
-        result = lu.LuaUnit.expandClasses( { { 'MyTestToto1', MyTestToto1 } } )
+        result = lu.LuaUnit:expandClasses( { { 'MyTestToto1', MyTestToto1 } } )
         lu.assertEquals( result, { 
             {'MyTestToto1.test1', MyTestToto1 },
             {'MyTestToto1.test2', MyTestToto1 },
@@ -3148,7 +3160,7 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
     function TestLuaUnitExecution:setUp()
         executedTests = {}
         lu.LuaUnit.isTestNameOld = lu.LuaUnit.isTestName
-        lu.LuaUnit.isTestName = function( s ) return (string.sub(s,1,6) == 'MyTest') end
+        lu.LuaUnit.isTestName = function( _, s ) return (string.sub(s,1,6) == 'MyTest') end
     end
 
     function TestLuaUnitExecution:oneInstanceExists()
@@ -3167,7 +3179,8 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
     end
 
     function TestLuaUnitExecution:test_collectTests()
-        local allTests = lu.LuaUnit.collectTests()
+        local runner = lu.LuaUnit.new()
+        local allTests = runner:collectTests()
         lu.assertEquals( allTests, {"MyTestFunction", "MyTestOk", "MyTestToto1", "MyTestToto2","MyTestWithErrorsAndFailures"})
     end
 
@@ -4124,10 +4137,10 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
                                   runner.runSuite, runner, 'MyTestOk.foobar')
         lu.assertEquals( #lu.LuaUnit.instances, 1)
         lu.assertErrorMsgContains('Instance must be a table or a function',
-                                  runner.expandClasses, {{'foobar', 'INVALID'}})
+                                  runner.expandClasses, runner, {{'foobar', 'INVALID'}})
         lu.assertEquals( #lu.LuaUnit.instances, 1)
         lu.assertErrorMsgContains('Could not find method in class',
-                                  runner.expandClasses, {{'MyTestOk.foobar', {}}})
+                                  runner.expandClasses, runner, {{'MyTestOk.foobar', {}}})
         lu.assertEquals( #lu.LuaUnit.instances, 1)
     end
 


### PR DESCRIPTION
This allows specifying the prefix for test and method names, so the tests can be now defined as follows:

```
function shouldValidateArguments()
...
end
```

or

```
function should_validate_arguments()
...
end
```

If not provided, the behavior is unchanged and it defaults to the current `test` prefix.

Example:
```
local runner = lu.LuaUnit.new()
runner:setOutputType( "text" )
os.exit( runner:runSuite( "-t", "should" ) )
```