### PR TITLE
Allow passing arguments to runSuiteByInstances

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -922,12 +922,13 @@ Example::
 
 
 
-.. function:: runner:runSuiteByInstances( listOfNameAndInstances  )
+.. function:: runner:runSuiteByInstances( listOfNameAndInstances, [arguments] )
 
 This function runs test without performing the global test collection process on the global namespace, the test
 are explicitely provided as argument, along with their names.
 
-Before execution, the function will parse the script command-line, like :func:`funner:runSuite()`.
+Arguments are handled the same way as in :func:`runner:runSuite()`, in particular, if no arguments are supplied, the
+function will parse the script command-line.
 
 Input is provided as a list of { name, test_instance } . test_instance can either be a function or a table containing 
 test functions starting with the prefix "test".

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -3409,14 +3409,14 @@ end
     end
 
     function M.LuaUnit:runSuite( ... )
-        testNames = self:initFromArguments(...)
+        local testNames = self:initFromArguments(...)
         self:registerSuite()
         self:internalRunSuiteByNames( testNames or M.LuaUnit.collectTests() )
         self:unregisterSuite()
         return self.result.notSuccessCount
     end
 
-    function M.LuaUnit:runSuiteByInstances( listOfNameAndInst, commandLineArguments )
+    function M.LuaUnit:runSuiteByInstances( listOfNameAndInst, ... )
         --[[
         Run all test functions or tables provided as input.
 
@@ -3426,7 +3426,7 @@ end
         return the number of failures and errors, 0 meaning success
         ]]
         -- parse the command-line arguments
-        testNames = self:initFromArguments( commandLineArguments )
+        self:initFromArguments( ... )
         self:registerSuite()
         self:internalRunSuiteByInstances( listOfNameAndInst )
         self:unregisterSuite()

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -3194,6 +3194,15 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
         lu.assertEquals( executedTests[7], "MyTestFunction" )
     end
 
+    function TestLuaUnitExecution:test_runSuiteWithArguments()
+      local runner = lu.LuaUnit.new()
+      runner:setOutputType( "NIL" )
+      runner:runSuite( 'MyTestToto2', 'MyTestToto1', 'MyTestFunction', '-x', 'test1', '-p', 'test%a$' )
+      lu.assertEquals( #executedTests, 2 )
+      lu.assertTableContains( executedTests, "MyTestToto1:testa" )
+      lu.assertTableContains( executedTests, "MyTestToto1:testb" )
+    end
+
     function TestLuaUnitExecution:testRunSomeTestByGlobalInstance( )
         lu.assertEquals( #executedTests, 0 )
         local runner = lu.LuaUnit.new()
@@ -3226,6 +3235,27 @@ TestLuaUnitExecution = { __class__ = 'TestLuaUnitExecution' }
         lu.assertEquals( executedTests[1], 'MyLocalTestToto1:test1')
         lu.assertEquals( executedTests[2], 'MyLocalTestToto2:test2')
         lu.assertEquals( executedTests[3], 'MyLocalTestFunction')
+    end
+
+    function TestLuaUnitExecution:testRunSomeTestByLocalInstanceWithArguments()
+      local MyLocalTestIncluded = {}
+      function MyLocalTestIncluded:test1() table.insert(executedTests, "MyLocalTestIncluded:test1") end
+      function MyLocalTestIncluded:test2() table.insert(executedTests, "MyLocalTestIncluded:test2") end
+      local MyLocalTestExcluded = {}
+      function MyLocalTestExcluded:test1() table.insert(executedTests, "MyLocalTestExcluded:test1") end
+      local function MyLocalTestFunction1() table.insert(executedTests, "MyLocalTestFunction1") end
+
+      lu.assertEquals(#executedTests, 0)
+      local runner = lu.LuaUnit.new()
+      runner:setOutputType("NIL")
+      runner:runSuiteByInstances( {
+        { "MyLocalTestIncluded", MyLocalTestIncluded },
+        { "MyLocalTestExcluded", MyLocalTestExcluded },
+        { "MyLocalTestFunction1", MyLocalTestFunction1 },
+      }, "-p", "1$", "-x", "Excluded" )
+      lu.assertEquals(#executedTests, 2)
+      lu.assertEquals(executedTests[1], "MyLocalTestIncluded:test1")
+      lu.assertEquals(executedTests[2], "MyLocalTestFunction1")
     end
 
     function TestLuaUnitExecution:testRunReturnsNumberOfFailures()


### PR DESCRIPTION
This allows passing multiple arguments to `runSuiteByInstances` explicitly, without parsing command line. If no arguments are passed, it will still parse command line arguments.

It should ease making test runners that accept (different) arguments on the command line themselves and pass them to `runSuiteByInstances`.

Currently, `runSuiteByInstances` accepts `commandLineArguments` as its second parameter, but it allows only for one value to be passed. If you try to give it more values (like '--exclude', 'something') it will error as only first value is passed to function and command line option is missing value. Passing table of arguments doesn't help either, because `initFromArguments` accepts multiple values and wraps them in additional table which breaks parsing. To pass different arguments than those provided in command line, you have to modify `arg` table.
