### PR TITLE
Add local to local variables

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -3409,7 +3409,7 @@ end
     end
 
     function M.LuaUnit:runSuite( ... )
-        testNames = self:initFromArguments(...)
+        local testNames = self:initFromArguments(...)
         self:registerSuite()
         self:internalRunSuiteByNames( testNames or M.LuaUnit.collectTests() )
         self:unregisterSuite()
@@ -3426,7 +3426,7 @@ end
         return the number of failures and errors, 0 meaning success
         ]]
         -- parse the command-line arguments
-        testNames = self:initFromArguments( commandLineArguments )
+        local testNames = self:initFromArguments( commandLineArguments )
         self:registerSuite()
         self:internalRunSuiteByInstances( listOfNameAndInst )
         self:unregisterSuite()


### PR DESCRIPTION
Our runtime is fairly strict, so it errors in these places:
`myfile.lua: in lib/test/luaunit, near line 3429: globals error: writing nil to 'testNames'`
Fixed by adding the local keyword.