### PR TITLE
respect metatable's __eq in luaunit assertEquals

### DIFF
--- a/luaunit.lua
+++ b/luaunit.lua
@@ -29,7 +29,6 @@ M.PRINT_TABLE_REF_IN_ERROR_MSG = false
 M.LINE_LENGTH = 80
 M.TABLE_DIFF_ANALYSIS_THRESHOLD = 10    -- display deep analysis for more than 10 items
 M.LIST_DIFF_ANALYSIS_THRESHOLD  = 10    -- display deep analysis for more than 10 items
-M.RESPECT_METATABLE_EQUALS = true
 
 -- this setting allow to remove entries from the stack-trace, for 
 -- example to hide a call to a framework which would be calling luaunit
@@ -1232,6 +1231,13 @@ local _recursion_cache_MT = {
     }
 }
 
+local function _get_mt_eq(t)
+    local mt = getmetatable(t)
+    if mt then
+        return mt.__eq
+    end
+end
+
 local function _is_table_equals(actual, expected, cycleDetectTable, marginForAlmostEqual)
     --[[Returns true if both table are equal.
 
@@ -1260,21 +1266,15 @@ local function _is_table_equals(actual, expected, cycleDetectTable, marginForAlm
         return actual == expected
     end
 
-    if M.RESPECT_METATABLE_EQUALS then
-        if actual == expected then
-           return true
-        end
-        local mt_actual = getmetatable(actual)
-        if mt_actual ~= nil and mt_actual.__eq ~= nil then
-            return false
-        else
-            local mt_expected = getmetatable(expected)
-            if mt_expected ~= nil and mt_expected.__eq ~= nil then
-                return false
-            end
-        end
+    -- Note: one cannot reliably check here because __eq method can be present but inaccessible in Lua.
+    local is_ok, mt_eq_fn = pcall(_get_mt_eq, actual)
+    if not (is_ok and mt_eq_fn) then
+        is_ok, mt_eq_fn = pcall(_get_mt_eq, expected)
     end
- 
+    if is_ok and mt_eq_fn then
+        -- The order of aruments is independent from the source of __eq function, the same as in luaV_equalobj.
+        return mt_eq_fn(actual, expected)
+    end
 
     cycleDetectTable = cycleDetectTable or { actual={}, expected={} }
     if cycleDetectTable.actual[ actual ] then

--- a/luaunit.lua
+++ b/luaunit.lua
@@ -29,6 +29,7 @@ M.PRINT_TABLE_REF_IN_ERROR_MSG = false
 M.LINE_LENGTH = 80
 M.TABLE_DIFF_ANALYSIS_THRESHOLD = 10    -- display deep analysis for more than 10 items
 M.LIST_DIFF_ANALYSIS_THRESHOLD  = 10    -- display deep analysis for more than 10 items
+M.RESPECT_METATABLE_EQUALS = true
 
 -- this setting allow to remove entries from the stack-trace, for 
 -- example to hide a call to a framework which would be calling luaunit
@@ -1258,6 +1259,22 @@ local function _is_table_equals(actual, expected, cycleDetectTable, marginForAlm
         -- other types compare directly
         return actual == expected
     end
+
+    if M.RESPECT_METATABLE_EQUALS then
+        if actual == expected then
+           return true
+        end
+        local mt_actual = getmetatable(actual)
+        if mt_actual ~= nil and mt_actual.__eq ~= nil then
+            return false
+        else
+            local mt_expected = getmetatable(expected)
+            if mt_expected ~= nil and mt_expected.__eq ~= nil then
+                return false
+            end
+        end
+    end
+ 
 
     cycleDetectTable = cycleDetectTable or { actual={}, expected={} }
     if cycleDetectTable.actual[ actual ] then

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1291,6 +1291,83 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         assertFailure( lu.assertEquals, {[{"one"}]=1,[{"one"}]=1}, {[{"one"}]=1} )
     end
 
+    function TestLuaUnitAssertions:test_assertEqualsTableWithMetatable__eq()
+        local next_fn = function(t, key)
+            local k, v = next(t, key)
+            while k ~= nil and k:sub(1, 1) == "_" do
+                k, v = next(t, k)
+            end
+            return k, v
+        end
+        local mt = {
+            __eq = function(t1, t2)
+                if t1._id == nil or t2._id == nil then
+                    return false
+                end
+                return t1._id == t2._id
+            end,
+            __pairs = function(t)
+                return next_fn, t
+            end
+        }
+        local mt_no_eq = {
+            __pairs = mt.__pairs
+        }
+        do
+            local obj1 = setmetatable({_id=1, name="A"}, mt)
+            local obj2 = setmetatable({_id=2, name="A"}, mt)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj1, {name="A"})
+            lu.assertNotEquals({name="A"}, obj1)
+
+            local obj1_second = setmetatable({_id=1, name="Changed"}, mt)
+            lu.assertEquals(obj1, obj1_second)
+
+            setmetatable(obj1, mt_no_eq)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj2, obj1)
+            lu.assertEquals(obj1, {name="A"})
+            lu.assertEquals({name="A"}, obj1)
+            setmetatable(obj2, mt_no_eq)
+            lu.assertEquals(obj1, obj2)
+        end
+
+        do -- now "empty" objects
+            local obj1 = setmetatable({_id=1}, mt)
+            local obj2 = setmetatable({_id=2}, mt)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj1, {})
+            lu.assertNotEquals({}, obj1)
+
+            local obj1_second = setmetatable({_id=1}, mt)
+            lu.assertEquals(obj1, obj1_second)
+
+            setmetatable(obj1, mt_no_eq)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj2, obj1)
+            lu.assertEquals(obj1, {})
+            lu.assertEquals({}, obj1)
+            setmetatable(obj2, mt_no_eq)
+            lu.assertEquals(obj1, obj2)
+        end
+
+        do -- and completely empty objects
+            local obj1 = setmetatable({}, mt)
+            local obj2 = setmetatable({}, mt)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj1, {})
+            lu.assertNotEquals({}, obj1)
+
+            setmetatable(obj1, mt_no_eq)
+            lu.assertNotEquals(obj1, obj2)
+            lu.assertNotEquals(obj2, obj1)
+            lu.assertEquals(obj1, {})
+            lu.assertEquals({}, obj1)
+            setmetatable(obj2, mt_no_eq)
+            lu.assertEquals(obj1, obj2)
+        end
+    end
+
     function TestLuaUnitAssertions:test_assertAlmostEquals()
         lu.assertAlmostEquals( 1, 1, 0.1 )
         lu.assertAlmostEquals( 1, 1 ) -- default margin (= M.EPS)

--- a/test/test_luaunit.lua
+++ b/test/test_luaunit.lua
@@ -1301,6 +1301,8 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
         end
         local mt = {
             __eq = function(t1, t2)
+                -- Note: We deliberately don't check whether the objects t1 and t2 are of the same type (e.g., cheching it's metatable),
+                --       in order to test that the __eq method is taken from the first or the second object, if the first object does not have it.
                 if t1._id == nil or t2._id == nil then
                     return false
                 end
@@ -1365,6 +1367,74 @@ TestLuaUnitAssertions = { __class__ = 'TestLuaUnitAssertions' }
             lu.assertEquals({}, obj1)
             setmetatable(obj2, mt_no_eq)
             lu.assertEquals(obj1, obj2)
+        end
+
+        do -- nested tables with metatables
+            local objA10 = {name="A", nested=setmetatable({_id=10, p="a"}, mt)}
+            local objA11 = {name="A", nested=setmetatable({_id=11, p="a"}, mt)}
+            lu.assertNotEquals(objA10, objA11)
+            lu.assertNotEquals(objA11, objA10)
+
+            -- compare with the table without __eq method.
+            lu.assertEquals   (objA10, {name="A", nested={_id=10, p="a"}})
+            lu.assertNotEquals(objA10, {name="A", nested={        p="a"}})
+
+            lu.assertEquals({name="A", nested={_id=10, p="a"}}, objA10)
+            lu.assertNotEquals({name="A", nested={        p="a"}}, objA10)
+
+            local objA10_second = {name="A", nested=setmetatable({_id=10, p="b"}, mt)}
+            lu.assertEquals(objA10, objA10_second)
+            lu.assertEquals(objA10_second, objA10)
+
+            local objB10 = {name="B", nested=setmetatable({_id=10, p="a"}, mt)}
+            lu.assertNotEquals(objA10, objB10)
+            lu.assertNotEquals(objB10, objA10)
+
+            -- one of the objects does not have __eq method.
+            setmetatable(objA10.nested, mt_no_eq)
+
+            lu.assertNotEquals(objA10, objA11)
+            lu.assertNotEquals(objA11, objA10)
+
+            lu.assertEquals(objA10, objA10_second)
+            lu.assertEquals(objA10_second, objA10)
+
+            lu.assertNotEquals(objA10, objB10)
+            lu.assertNotEquals(objB10, objA10)
+
+            -- compare with the object without __eq method.
+            lu.assertEquals(objA10, {name="A", nested={p="a"}})
+            lu.assertEquals({name="A", nested={p="a"}}, objA10)
+        end
+    end
+
+    function TestLuaUnitAssertions:test_assertEqualsTableWithProtectedMetatable()
+        do -- expected BUG in luaunit: the result should be lu.assertEquals(t1, t2).
+            local mt ={ __metatable = "protected metatable", __eq = function() return true end }
+            local t1 = setmetatable({name="A"}, mt)
+            local t2 = setmetatable({name="B"}, mt)
+            -- BUG
+            lu.assertNotEquals(t1, t2)
+        end
+
+        do -- expected BUG in luaunit: the result should be lu.assertNotEquals(t1, t2).
+            local mt ={ __metatable = "protected metatable", __eq = function() return false end }
+            local t1 = setmetatable({}, mt)
+            local t2 = setmetatable({}, mt)
+            lu.assertEquals(t1, t2)
+        end
+        do
+            local mt ={ __metatable = 123, __eq = function() return false end }
+            local t1 = setmetatable({}, mt)
+            local t2 = setmetatable({}, mt)
+            lu.assertEquals(t1, t2)
+        end
+
+        do
+            local mt ={ __metatable = "protected metatable", __eq = function() return false end }
+            local t1 = setmetatable({name="A"}, mt)
+            local t2 = setmetatable({name="A"}, mt)
+            lu.assertEquals(t1, t2)
         end
     end
 


### PR DESCRIPTION
If there is `__eq` in a table's metatable, then `luaunit.assertEquals` does not take it into account.
However, in real projects it often happens that object comparison shall be done in accordance with special rules, and one cannot simply expose all key-values of a table because of several reasons, e.g., they break JSON encoding or there is some special userdata, etc.

According to the documentation https://www.lua.org/manual/5.5/manual.html#2.4
> **__eq:** the equal (==) operation. Behavior similar to the addition operation, except that Lua will try a metamethod only when the values being compared are either both tables or both full userdata and they are not primitively equal. The result of the call is always converted to a boolean.
**__add:** the addition (`+`) operation. If any operand for an addition is not a number, Lua will try to call a metamethod. It starts by checking the first operand (even if it is a number); if that operand does not define a metamethod for `__add`, then Lua will check the second operand. If Lua can find a metamethod, it calls the metamethod with the two operands as arguments, and the result of the call (adjusted to one value) is the result of the operation. Otherwise, if no metamethod is found, Lua raises an error.

I am proposing that if there is `getmetatable(t).__eq` either for `actual` or `expected` Lua tables then luaunit doesn't manually compare key-value pairs. If it somehow breaks somebody's code then there is the Boolean option `RESPECT_METATABLE_EQUALS` (default `true`) to disable such behavior. 